### PR TITLE
Upgrade dependency in-eu to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-emotion": "^9.1.2"
   },
   "devDependencies": {
-    "@segment/in-eu": "^0.1.1",
+    "@segment/in-eu": "^0.2.0",
     "@storybook/addon-options": "^3.4.1",
     "@storybook/react": "^3.4.0",
     "@storybook/storybook-deployer": "^2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,9 +187,9 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@segment/in-eu@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@segment/in-eu/-/in-eu-0.1.1.tgz#3d4d3ce9d4487382788bf715f63790e9b029bb94"
+"@segment/in-eu@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@segment/in-eu/-/in-eu-0.2.0.tgz#1ba8897305abe3cd9255f02f663f089dfa8f5bf3"
   dependencies:
     jstz "^2.0.0"
 


### PR DESCRIPTION
Reference: https://github.com/segmentio/in-eu/pull/2

@ucarion has added the ISO 3166 country codes of dependent territories of states subject to the GDPR.

Let's use the latest version of https://github.com/segmentio/in-eu 🙌 

cc @nettofarah @Rowno 