### PR TITLE
Move initialPreferences to props

### DIFF
--- a/src/consent-manager/index.js
+++ b/src/consent-manager/index.js
@@ -4,11 +4,6 @@ import ConsentManagerBuilder from '../consent-manager-builder'
 import Container from './container'
 import {ADVERTISING_CATEGORIES, FUNCTIONAL_CATEGORIES} from './categories'
 
-const initialPreferences = {
-  marketingAndAnalytics: null,
-  advertising: null,
-  functional: null
-}
 
 export default class ConsentManager extends PureComponent {
   static displayName = 'ConsentManager'
@@ -25,7 +20,8 @@ export default class ConsentManager extends PureComponent {
     preferencesDialogTitle: PropTypes.node,
     preferencesDialogContent: PropTypes.node.isRequired,
     cancelDialogTitle: PropTypes.node,
-    cancelDialogContent: PropTypes.node.isRequired
+    cancelDialogContent: PropTypes.node.isRequired,
+    initialPreferences: PropTypes.object
   }
 
   static defaultProps = {
@@ -36,7 +32,12 @@ export default class ConsentManager extends PureComponent {
     bannerTextColor: '#fff',
     bannerBackgroundColor: '#1f4160',
     preferencesDialogTitle: 'Website Data Collection Preferences',
-    cancelDialogTitle: 'Are you sure you want to cancel?'
+    cancelDialogTitle: 'Are you sure you want to cancel?',
+    initialPreferences: {
+      marketingAndAnalytics: null,
+      advertising: null,
+      functional: null
+    }
   }
 
   render() {
@@ -52,7 +53,8 @@ export default class ConsentManager extends PureComponent {
       preferencesDialogTitle,
       preferencesDialogContent,
       cancelDialogTitle,
-      cancelDialogContent
+      cancelDialogContent,
+      initialPreferences
     } = this.props
 
     return (

--- a/src/consent-manager/index.js
+++ b/src/consent-manager/index.js
@@ -4,7 +4,6 @@ import ConsentManagerBuilder from '../consent-manager-builder'
 import Container from './container'
 import {ADVERTISING_CATEGORIES, FUNCTIONAL_CATEGORIES} from './categories'
 
-
 export default class ConsentManager extends PureComponent {
   static displayName = 'ConsentManager'
 


### PR DESCRIPTION
By allowing `initialPreferences` to be passed from `window.consentManagerConfig` the standalone app may have more appeal. It certainly would do for me.

Since you could then easily use the standalone app with some custom rules for the initial prefs like using to doNotTrack to stop advertising integrations by default:

```diff
window.consentManagerConfig = function(exports) {
    var React = exports.React;
    var inEU = exports.inEU;
+   var doNotTrack = exports.doNotTrack;

    var bannerContent = React.createElement(
    'span',
    null,
    'We use cookies (and other similar technologies) to collect data to improve your experience on our site. By using our website, you՚re agreeing to the collection of data as described in our',
    ' ',
    React.createElement(
        'a',
        {href: '/docs/legal/website-data-collection-policy/', target: '_blank'},
        'Website Data Collection Policy'
    ),
    '.'
    )
    var preferencesDialogTitle = 'Website Data Collection Preferences'
    var preferencesDialogContent = 'We use data collected by cookies and JavaScript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site.'
    var cancelDialogTitle = 'Are you sure you want to cancel?'
    var cancelDialogContent = 'Your preferences have not been saved. By continuing to use our website, you՚re agreeing to our Website Data Collection Policy.'

    return {
        container: '#target-container',
        writeKey: '<your-segment-write-key>',
        shouldRequireConsent: inEU,
+       initialPreferences: {marketingAndAnalytics: false, functional:true, advertising: !doNotTrack()},
        bannerContent: bannerContent,
        preferencesDialogTitle: preferencesDialogTitle,
        preferencesDialogContent: preferencesDialogContent,
        cancelDialogTitle: cancelDialogTitle,
        cancelDialogContent: cancelDialogContent
    }
}
```