### PR TITLE
Adding localization to the component API

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The `shouldRequireConsent` option isn't supported and the `otherWriteKeys` optio
   data-container="#target-container"
   data-writeKey="<your-segment-write-key>"
   data-bannerContent="We use cookies (and other similar technologies) to collect data to improve your experience on our site."
+  data-bannerSubContent="You can change your preferences at any time."
   data-preferencesDialogTitle="Website Data Collection Preferences"
   data-preferencesDialogContent="We use data collected by cookies and JavaScript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site."
   data-cancelDialogTitle="Are you sure you want to cancel?"
@@ -119,6 +120,7 @@ All the options are supported. The callback function also receives these exports
       ),
       '.'
     )
+    var bannerSubContent = 'You can change your preferences at any time.'
     var preferencesDialogTitle = 'Website Data Collection Preferences'
     var preferencesDialogContent = 'We use data collected by cookies and JavaScript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site.'
     var cancelDialogTitle = 'Are you sure you want to cancel?'
@@ -129,6 +131,7 @@ All the options are supported. The callback function also receives these exports
       writeKey: '<your-segment-write-key>',
       shouldRequireConsent: inEU,
       bannerContent: bannerContent,
+      bannerSubContent: bannerSubContent,
       preferencesDialogTitle: preferencesDialogTitle,
       preferencesDialogContent: preferencesDialogContent,
       cancelDialogTitle: cancelDialogTitle,
@@ -190,6 +193,12 @@ Type: `PropTypes.node`
 
 The consent of the consent banner.
 
+##### bannerSubContent
+
+Type: `PropTypes.node`
+
+The call to action under the content in the consent banner.
+
 ##### bannerTextColor
 
 Type: `string`<br>
@@ -248,6 +257,7 @@ export default function() {
       </a>.
     </span>
   )
+  const bannerSubContent = 'You can change your preferences at any time.'
   const preferencesDialogTitle = 'Website Data Collection Preferences'
   const preferencesDialogContent = 'We use data collected by cookies and JavaScript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site.'
   const cancelDialogTitle = 'Are you sure you want to cancel?'
@@ -259,6 +269,7 @@ export default function() {
         writeKey="<your-segment-write-key>"
         shouldRequireConsent={inEU}
         bannerContent={bannerContent}
+        bannerSubContent={bannerSubContent}
         preferencesDialogTitle={preferencesDialogTitle}
         preferencesDialogContent={preferencesDialogContent}
         cancelDialogTitle={cancelDialogTitle}

--- a/src/consent-manager/banner.js
+++ b/src/consent-manager/banner.js
@@ -59,6 +59,7 @@ export default class Banner extends PureComponent {
     onAccept: PropTypes.func.isRequired,
     onChangePreferences: PropTypes.func.isRequired,
     content: PropTypes.node.isRequired,
+    subContent: PropTypes.node.isRequired,
     backgroundColor: PropTypes.string.isRequired,
     textColor: PropTypes.string.isRequired
   }
@@ -69,6 +70,7 @@ export default class Banner extends PureComponent {
       onAccept,
       onChangePreferences,
       content,
+      subContent,
       backgroundColor,
       textColor
     } = this.props
@@ -82,11 +84,9 @@ export default class Banner extends PureComponent {
         <Content>
           <P>{content}</P>
           <P>
-            You can{' '}
             <button type="button" onClick={onChangePreferences}>
-              change your preferences
-            </button>{' '}
-            at any time.
+              {subContent}
+            </button>
           </P>
         </Content>
 

--- a/src/consent-manager/container.js
+++ b/src/consent-manager/container.js
@@ -25,6 +25,7 @@ export default class Container extends PureComponent {
     isConsentRequired: PropTypes.bool.isRequired,
     implyConsentOnInteraction: PropTypes.bool.isRequired,
     bannerContent: PropTypes.node.isRequired,
+    bannerSubContent: PropTypes.node.isRequired,
     bannerTextColor: PropTypes.string.isRequired,
     bannerBackgroundColor: PropTypes.string.isRequired,
     preferencesDialogTitle: PropTypes.node.isRequired,
@@ -45,6 +46,7 @@ export default class Container extends PureComponent {
       preferences,
       isConsentRequired,
       bannerContent,
+      bannerSubContent,
       bannerTextColor,
       bannerBackgroundColor,
       preferencesDialogTitle,
@@ -78,6 +80,7 @@ export default class Container extends PureComponent {
               onAccept={this.handleBannerAccept}
               onChangePreferences={this.openDialog}
               content={bannerContent}
+              subContent={bannerSubContent}
               textColor={bannerTextColor}
               backgroundColor={bannerBackgroundColor}
             />

--- a/src/consent-manager/container.js
+++ b/src/consent-manager/container.js
@@ -25,7 +25,7 @@ export default class Container extends PureComponent {
     isConsentRequired: PropTypes.bool.isRequired,
     implyConsentOnInteraction: PropTypes.bool.isRequired,
     bannerContent: PropTypes.node.isRequired,
-    bannerSubContent: PropTypes.node.isRequired,
+    bannerSubContent: PropTypes.string.isRequired,
     bannerTextColor: PropTypes.string.isRequired,
     bannerBackgroundColor: PropTypes.string.isRequired,
     preferencesDialogTitle: PropTypes.node.isRequired,

--- a/src/consent-manager/index.js
+++ b/src/consent-manager/index.js
@@ -20,7 +20,7 @@ export default class ConsentManager extends PureComponent {
     implyConsentOnInteraction: PropTypes.bool,
     cookieDomain: PropTypes.string,
     bannerContent: PropTypes.node.isRequired,
-    bannerSubContent: PropTypes.node.string,
+    bannerSubContent: PropTypes.string,
     bannerTextColor: PropTypes.string,
     bannerBackgroundColor: PropTypes.string,
     preferencesDialogTitle: PropTypes.node,

--- a/src/consent-manager/index.js
+++ b/src/consent-manager/index.js
@@ -20,6 +20,7 @@ export default class ConsentManager extends PureComponent {
     implyConsentOnInteraction: PropTypes.bool,
     cookieDomain: PropTypes.string,
     bannerContent: PropTypes.node.isRequired,
+    bannerSubContent: PropTypes.node.string,
     bannerTextColor: PropTypes.string,
     bannerBackgroundColor: PropTypes.string,
     preferencesDialogTitle: PropTypes.node,
@@ -34,6 +35,7 @@ export default class ConsentManager extends PureComponent {
     implyConsentOnInteraction: true,
     cookieDomain: undefined,
     bannerTextColor: '#fff',
+    bannerSubContent: 'You can change your preferences at any time.',
     bannerBackgroundColor: '#1f4160',
     preferencesDialogTitle: 'Website Data Collection Preferences',
     cancelDialogTitle: 'Are you sure you want to cancel?'
@@ -47,6 +49,7 @@ export default class ConsentManager extends PureComponent {
       implyConsentOnInteraction,
       cookieDomain,
       bannerContent,
+      bannerSubContent,
       bannerTextColor,
       bannerBackgroundColor,
       preferencesDialogTitle,
@@ -83,6 +86,7 @@ export default class ConsentManager extends PureComponent {
             saveConsent={saveConsent}
             implyConsentOnInteraction={implyConsentOnInteraction}
             bannerContent={bannerContent}
+            bannerSubContent={bannerSubContent}
             bannerTextColor={bannerTextColor}
             bannerBackgroundColor={bannerBackgroundColor}
             preferencesDialogTitle={preferencesDialogTitle}

--- a/tools/standalone.html
+++ b/tools/standalone.html
@@ -56,6 +56,7 @@
     data-writeKey="mA3XTMcavCUOQo5DL56VIHWcJMsyhAI7"
     data-otherWriteKeys="vMRS7xbsjH97Bb2PeKbEKvYDvgMm5T3l"
     data-bannerContent="We use cookies (and other similar technologies) to collect data to improve your experience on our site."
+    data-bannerSubContent="You can change your preferences at any time."
     data-preferencesDialogTitle="Website Data Collection Preferences"
     data-preferencesDialogContent="We use data collected by cookies and JavaScript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site."
     data-cancelDialogTitle="Are you sure you want to cancel?"

--- a/tools/stories/consent-manager.js
+++ b/tools/stories/consent-manager.js
@@ -17,6 +17,7 @@ const bannerContent = (
     </a>.
   </span>
 )
+const bannerSubContent = 'You can manage your preferences here!'
 const preferencesDialogTitle = 'Website Data Collection Preferences'
 const preferencesDialogContent = (
   <div>
@@ -63,6 +64,7 @@ export default () => {
         writeKey="mA3XTMcavCUOQo5DL56VIHWcJMsyhAI7"
         otherWriteKeys={['vMRS7xbsjH97Bb2PeKbEKvYDvgMm5T3l']}
         bannerContent={bannerContent}
+        bannerSubContent={bannerSubContent}
         implyConsentOnInteraction={false}
         preferencesDialogTitle={preferencesDialogTitle}
         preferencesDialogContent={preferencesDialogContent}


### PR DESCRIPTION
Hello,

The idea is to respond this issue: https://github.com/segmentio/consent-manager/issues/27

I liked your component but i need to be able to customize the labels (to have it in French).

This is a quick (first) solution and i'm willing to go further by doing pretty much the same for the `cancel-dialog` buttons.

I would be glad to hear your feedbacks on this.

Cheers.