### PR TITLE
Customizable messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 # IDE
 .vscode/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 
 # IDE
 .vscode/
-.DS_Store

--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ The `shouldRequireConsent` option isn't supported and the `otherWriteKeys` optio
   data-preferencesDialogContent="We use data collected by cookies and JavaScript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site."
   data-cancelDialogTitle="Are you sure you want to cancel?"
   data-cancelDialogContent="Your preferences have not been saved. By continuing to use our website, you՚re agreeing to our Website Data Collection Policy."
+  data-translationMessages="{
+      'ui.save': 'Save',
+      'ui.cancel': 'Cancel',
+      'purpose.functional': [
+        React.createElement(
+          'p',
+          null,
+          'To monitor the performance of our site and to enhance your browsing experience.'
+        ),
+        React.createElement(
+          'p',
+          null,
+          'For example, these tools enable you to communicate with us via live chat.'
+        )
+      ]}"
 ></script>
 ```
 
@@ -126,6 +141,23 @@ All the options are supported. The callback function also receives these exports
     var cancelDialogTitle = 'Are you sure you want to cancel?'
     var cancelDialogContent = 'Your preferences have not been saved. By continuing to use our website, you՚re agreeing to our Website Data Collection Policy.'
 
+    var translationMessages = {
+      'ui.save': 'Save',
+      'ui.cancel': 'Cancel',
+      'purpose.functional': [
+        React.createElement(
+          'p',
+          null,
+          'To monitor the performance of our site and to enhance your browsing experience.'
+        ),
+        React.createElement(
+          'p',
+          null,
+          'For example, these tools enable you to communicate with us via live chat.'
+        )
+      ]
+    }
+
     return {
       container: '#target-container',
       writeKey: '<your-segment-write-key>',
@@ -135,7 +167,8 @@ All the options are supported. The callback function also receives these exports
       preferencesDialogTitle: preferencesDialogTitle,
       preferencesDialogContent: preferencesDialogContent,
       cancelDialogTitle: cancelDialogTitle,
-      cancelDialogContent: cancelDialogContent
+      cancelDialogContent: cancelDialogContent,
+      translationMessages: translationMessages
     }
   }
 </script>
@@ -239,6 +272,12 @@ Type: `PropTypes.node`
 
 The content of the cancel dialog.
 
+##### translationMessages
+
+Type: `PropTypes.Object`
+
+Translation messages to customize any text in UI.
+
 #### Example
 
 ```javascript
@@ -262,6 +301,22 @@ export default function() {
   const preferencesDialogContent = 'We use data collected by cookies and JavaScript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site.'
   const cancelDialogTitle = 'Are you sure you want to cancel?'
   const cancelDialogContent = 'Your preferences have not been saved. By continuing to use our website, you՚re agreeing to our Website Data Collection Policy.'
+  const translationMessages = {
+    'ui.save': 'Save',
+    'ui.cancel': 'Cancel',
+    'purpose.functional': [
+      React.createElement(
+        'p',
+        null,
+        'To monitor the performance of our site and to enhance your browsing experience.'
+      ),
+      React.createElement(
+        'p',
+        null,
+        'For example, these tools enable you to communicate with us via live chat.'
+      )
+    ]
+  }
 
   return (
     <div>
@@ -274,6 +329,7 @@ export default function() {
         preferencesDialogContent={preferencesDialogContent}
         cancelDialogTitle={cancelDialogTitle}
         cancelDialogContent={cancelDialogContent}
+        translationMessages={translationMessages}
       />
 
       <button type="button" onClick={openConsentManager}>

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The following global variables are also exposed:
 #### Data Attributes
 
 The `shouldRequireConsent` option isn't supported and the `otherWriteKeys` option should be a comma separated list.
+The `translationMessages` option isn't supported.
 
 *Note: the data attributes [won't work in Internet Explorer][currentScript] (Edge works fine though).*
 
@@ -276,7 +277,7 @@ The content of the cancel dialog.
 
 Type: `PropTypes.Object`
 
-Translation messages to customize any text in UI.
+Translation messages to customize any text in UI (works only with options passed as callback).
 
 #### Example
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/consent-manager",
-  "version": "1.4.1",
+  "version": "1.4.0",
   "description": "Drop-in consent management plugin for analytics.js",
   "keywords": [
     "gdpr",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/consent-manager",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Drop-in consent management plugin for analytics.js",
   "keywords": [
     "gdpr",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/consent-manager",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Drop-in consent management plugin for analytics.js",
   "keywords": [
     "gdpr",

--- a/src/consent-manager/cancel-dialog.js
+++ b/src/consent-manager/cancel-dialog.js
@@ -11,18 +11,19 @@ export default class CancelDialog extends PureComponent {
     onBack: PropTypes.func.isRequired,
     onConfirm: PropTypes.func.isRequired,
     title: PropTypes.node.isRequired,
-    content: PropTypes.node.isRequired
+    content: PropTypes.node.isRequired,
+    translate: PropTypes.func.isRequired
   }
 
   render() {
-    const {innerRef, onBack, title, content} = this.props
+    const {innerRef, onBack, title, content, translate} = this.props
 
     const buttons = (
       <div>
         <DefaultButton type="button" onClick={onBack}>
-          Go Back
+          {translate('ui.go_back')}
         </DefaultButton>
-        <RedButton type="submit">Yes, Cancel</RedButton>
+        <RedButton type="submit">{translate('ui.yes_cancel')}</RedButton>
       </div>
     )
 

--- a/src/consent-manager/container.js
+++ b/src/consent-manager/container.js
@@ -31,7 +31,8 @@ export default class Container extends PureComponent {
     preferencesDialogTitle: PropTypes.node.isRequired,
     preferencesDialogContent: PropTypes.node.isRequired,
     cancelDialogTitle: PropTypes.node.isRequired,
-    cancelDialogContent: PropTypes.node.isRequired
+    cancelDialogContent: PropTypes.node.isRequired,
+    translate: PropTypes.func.isRequired
   }
 
   state = {
@@ -52,7 +53,8 @@ export default class Container extends PureComponent {
       preferencesDialogTitle,
       preferencesDialogContent,
       cancelDialogTitle,
-      cancelDialogContent
+      cancelDialogContent,
+      translate
     } = this.props
     const {isDialogOpen, isCancelling} = this.state
     const marketingDestinations = []
@@ -99,6 +101,7 @@ export default class Container extends PureComponent {
             functional={preferences.functional}
             title={preferencesDialogTitle}
             content={preferencesDialogContent}
+            translate={translate}
           />
         )}
         {isCancelling && (
@@ -108,6 +111,7 @@ export default class Container extends PureComponent {
             onConfirm={this.handleCancelConfirm}
             title={cancelDialogTitle}
             content={cancelDialogContent}
+            translate={translate}
           />
         )}
       </div>

--- a/src/consent-manager/default-messages.js
+++ b/src/consent-manager/default-messages.js
@@ -1,0 +1,75 @@
+import React from 'react'
+
+export default {
+  translationMessages: {
+    'ui.save': 'Save',
+    'ui.cancel': 'Cancel',
+    'ui.yes': 'Yes',
+    'ui.no': 'No',
+    'ui.not_available': 'N/A',
+    'ui.go_back': 'Go Back',
+    'ui.yes_cancel': 'Yes, Cancel',
+    'ui.header.allow': 'Allow',
+    'ui.header.category': 'Category',
+    'ui.header.purpose': 'Purpose',
+    'ui.header.tools': 'Tools',
+    'aria.functional.allow': 'Allow functional tracking',
+    'aria.functional.disallow': 'Disallow functional tracking',
+    'aria.marketing.allow': 'Allow marketing and analytics tracking',
+    'aria.marketing.disallow': 'Disallow marketing and analytics tracking',
+    'aria.advertising.allow': 'Allow advertising tracking',
+    'aria.advertising.disallow': 'Disallow advertising tracking',
+    'category.functional': 'Functional',
+    'category.marketing': 'Marketing and Analytics',
+    'category.advertising': 'Advertising',
+    'category.essential': 'Essential',
+    'purpose.functional': [
+      React.createElement(
+        'p',
+        null,
+        'To monitor the performance of our site and to enhance your browsing experience.'
+      ),
+      React.createElement(
+        'p',
+        null,
+        'For example, these tools enable you to communicate with us via live chat.'
+      )
+    ],
+    'purpose.marketing': [
+      React.createElement(
+        'p',
+        null,
+        'To understand user behavior in order to provide you with a more relevant browsing experience or personalize the content on our site.'
+      ),
+      React.createElement(
+        'p',
+        null,
+        'For example, we collect information about which pages you visit to help us present more relevant information.'
+      )
+    ],
+    'purpose.advertising': [
+      React.createElement(
+        'p',
+        null,
+        'To personalize and measure the effectiveness of advertising on our site and other websites.'
+      ),
+      React.createElement(
+        'p',
+        null,
+        'For example, we may serve you a personalized ad based on the pages you visit on our site.'
+      )
+    ],
+    'purpose.essential': [
+      React.createElement(
+        'p',
+        null,
+        'We use browser cookies that are necessary for the site to work as intended.'
+      ),
+      React.createElement(
+        'p',
+        null,
+        'For example, we store your website data collection preferences so we can honor them if you return to our site. You can disable these cookies in your browser settings but if you do the site may not work as intended.'
+      )
+    ]
+  }
+}

--- a/src/consent-manager/index.js
+++ b/src/consent-manager/index.js
@@ -49,13 +49,13 @@ export default class ConsentManager extends PureComponent {
   constructor(props) {
     super(props)
 
-    let state = defaultMessages
-
-    if (this.props.translationMessages) {
-      state = Object.assign({}, defaultMessages, this.props.translationMessages)
+    this.state = {
+      translationMessages: Object.assign(
+        {},
+        defaultMessages.translationMessages,
+        this.props.translationMessages
+      )
     }
-
-    this.state = state
   }
 
   render() {

--- a/src/consent-manager/index.js
+++ b/src/consent-manager/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import ConsentManagerBuilder from '../consent-manager-builder'
 import Container from './container'
 import {ADVERTISING_CATEGORIES, FUNCTIONAL_CATEGORIES} from './categories'
+import defaultMessages from './default-messages'
 
 const initialPreferences = {
   marketingAndAnalytics: null,
@@ -27,7 +28,8 @@ export default class ConsentManager extends PureComponent {
     preferencesDialogContent: PropTypes.node.isRequired,
     onError: PropTypes.func,
     cancelDialogTitle: PropTypes.node,
-    cancelDialogContent: PropTypes.node.isRequired
+    cancelDialogContent: PropTypes.node.isRequired,
+    translationMessages: PropTypes.object
   }
 
   static defaultProps = {
@@ -40,7 +42,20 @@ export default class ConsentManager extends PureComponent {
     bannerSubContent: 'You can change your preferences at any time.',
     bannerBackgroundColor: '#1f4160',
     preferencesDialogTitle: 'Website Data Collection Preferences',
-    cancelDialogTitle: 'Are you sure you want to cancel?'
+    cancelDialogTitle: 'Are you sure you want to cancel?',
+    translationMessages: {}
+  }
+
+  constructor(props) {
+    super(props)
+
+    let state = defaultMessages
+
+    if (this.props.translationMessages) {
+      state = Object.assign({}, defaultMessages, this.props.translationMessages)
+    }
+
+    this.state = state
   }
 
   render() {
@@ -97,10 +112,15 @@ export default class ConsentManager extends PureComponent {
             preferencesDialogContent={preferencesDialogContent}
             cancelDialogTitle={cancelDialogTitle}
             cancelDialogContent={cancelDialogContent}
+            translate={this.translate}
           />
         )}
       </ConsentManagerBuilder>
     )
+  }
+
+  translate = key => {
+    return this.state.translationMessages[key]
   }
 
   handleMapCustomPreferences = ({destinations, preferences}) => {

--- a/src/consent-manager/preference-dialog.js
+++ b/src/consent-manager/preference-dialog.js
@@ -83,7 +83,8 @@ export default class PreferenceDialog extends PureComponent {
     advertising: PropTypes.bool,
     functional: PropTypes.bool,
     title: PropTypes.node.isRequired,
-    content: PropTypes.node.isRequired
+    content: PropTypes.node.isRequired,
+    translate: PropTypes.func.isRequired
   }
 
   static defaultProps = {
@@ -103,15 +104,16 @@ export default class PreferenceDialog extends PureComponent {
       advertising,
       functional,
       title,
-      content
+      content,
+      translate
     } = this.props
 
     const buttons = (
       <div>
         <DefaultButton type="button" onClick={onCancel}>
-          Cancel
+          {translate('ui.cancel')}
         </DefaultButton>
-        <GreenButton type="submit">Save</GreenButton>
+        <GreenButton type="submit">{translate('ui.save')}</GreenButton>
       </div>
     )
 
@@ -129,11 +131,17 @@ export default class PreferenceDialog extends PureComponent {
           <Table>
             <thead>
               <Row>
-                <ColumnHeading scope="col">Allow</ColumnHeading>
-                <ColumnHeading scope="col">Category</ColumnHeading>
-                <ColumnHeading scope="col">Purpose</ColumnHeading>
+                <ColumnHeading scope="col">
+                  {translate('ui.header.allow')}
+                </ColumnHeading>
+                <ColumnHeading scope="col">
+                  {translate('ui.header.category')}
+                </ColumnHeading>
+                <ColumnHeading scope="col">
+                  {translate('ui.header.purpose')}
+                </ColumnHeading>
                 <ColumnHeading scope="col" className={hideOnMobile}>
-                  Tools
+                  {translate('ui.header.tools')}
                 </ColumnHeading>
               </Row>
             </thead>
@@ -148,10 +156,10 @@ export default class PreferenceDialog extends PureComponent {
                       value="true"
                       checked={functional === true}
                       onChange={this.handleChange}
-                      aria-label="Allow functional tracking"
+                      aria-label={translate('aria.functional.allow')}
                       required
                     />{' '}
-                    Yes
+                    {translate('ui.yes')}
                   </label>
                   <label>
                     <input
@@ -160,23 +168,16 @@ export default class PreferenceDialog extends PureComponent {
                       value="false"
                       checked={functional === false}
                       onChange={this.handleChange}
-                      aria-label="Disallow functional tracking"
+                      aria-label={translate('aria.functional.disallow')}
                       required
                     />{' '}
-                    No
+                    {translate('ui.no')}
                   </label>
                 </InputCell>
-                <RowHeading scope="row">Functional</RowHeading>
-                <td>
-                  <p>
-                    To monitor the performance of our site and to enhance your
-                    browsing experience.
-                  </p>
-                  <p className={hideOnMobile}>
-                    For example, these tools enable you to communicate with us
-                    via live chat.
-                  </p>
-                </td>
+                <RowHeading scope="row">
+                  {translate('category.functional')}
+                </RowHeading>
+                <td>{translate('purpose.functional')}</td>
                 <td className={hideOnMobile}>
                   {functionalDestinations.map(d => d.name).join(', ')}
                 </td>
@@ -191,10 +192,10 @@ export default class PreferenceDialog extends PureComponent {
                       value="true"
                       checked={marketingAndAnalytics === true}
                       onChange={this.handleChange}
-                      aria-label="Allow marketing and analytics tracking"
+                      aria-label={translate('aria.marketing.allow')}
                       required
                     />{' '}
-                    Yes
+                    {translate('ui.yes')}
                   </label>
                   <label>
                     <input
@@ -203,24 +204,16 @@ export default class PreferenceDialog extends PureComponent {
                       value="false"
                       checked={marketingAndAnalytics === false}
                       onChange={this.handleChange}
-                      aria-label="Disallow marketing and analytics tracking"
+                      aria-label={translate('aria.marketing.disallow')}
                       required
                     />{' '}
-                    No
+                    {translate('ui.no')}
                   </label>
                 </InputCell>
-                <RowHeading scope="row">Marketing and Analytics</RowHeading>
-                <td>
-                  <p>
-                    To understand user behavior in order to provide you with a
-                    more relevant browsing experience or personalize the content
-                    on our site.
-                  </p>
-                  <p className={hideOnMobile}>
-                    For example, we collect information about which pages you
-                    visit to help us present more relevant information.
-                  </p>
-                </td>
+                <RowHeading scope="row">
+                  {translate('category.marketing')}
+                </RowHeading>
+                <td>{translate('purpose.marketing')}</td>
                 <td className={hideOnMobile}>
                   {marketingDestinations.map(d => d.name).join(', ')}
                 </td>
@@ -235,10 +228,10 @@ export default class PreferenceDialog extends PureComponent {
                       value="true"
                       checked={advertising === true}
                       onChange={this.handleChange}
-                      aria-label="Allow advertising tracking"
+                      aria-label={translate('aria.advertising.allow')}
                       required
                     />{' '}
-                    Yes
+                    {translate('ui.yes')}
                   </label>
                   <label>
                     <input
@@ -247,43 +240,27 @@ export default class PreferenceDialog extends PureComponent {
                       value="false"
                       checked={advertising === false}
                       onChange={this.handleChange}
-                      aria-label="Disallow advertising tracking"
+                      aria-label={translate('aria.advertising.disallow')}
                       required
                     />{' '}
-                    No
+                    {translate('ui.no')}
                   </label>
                 </InputCell>
-                <RowHeading scope="row">Advertising</RowHeading>
-                <td>
-                  <p>
-                    To personalize and measure the effectiveness of advertising
-                    on our site and other websites.
-                  </p>
-                  <p className={hideOnMobile}>
-                    For example, we may serve you a personalized ad based on the
-                    pages you visit on our site.
-                  </p>
-                </td>
+                <RowHeading scope="row">
+                  {translate('category.advertising')}
+                </RowHeading>
+                <td>{translate('purpose.advertising')}</td>
                 <td className={hideOnMobile}>
                   {advertisingDestinations.map(d => d.name).join(', ')}
                 </td>
               </Row>
 
               <Row>
-                <td>N/A</td>
-                <RowHeading scope="row">Essential</RowHeading>
-                <td>
-                  <p>
-                    We use browser cookies that are necessary for the site to
-                    work as intended.
-                  </p>
-                  <p>
-                    For example, we store your website data collection
-                    preferences so we can honor them if you return to our site.
-                    You can disable these cookies in your browser settings but
-                    if you do the site may not work as intended.
-                  </p>
-                </td>
+                <td>{translate('ui.not_available')}</td>
+                <RowHeading scope="row">
+                  {translate('category.essential')}
+                </RowHeading>
+                <td>{translate('purpose.essential')}</td>
                 <td className={hideOnMobile} />
               </Row>
             </tbody>

--- a/tools/standalone.html
+++ b/tools/standalone.html
@@ -81,7 +81,7 @@
       var preferencesDialogContent = 'We use data collected by cookies and JavaScript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site.'
       var cancelDialogTitle = 'Are you sure you want to cancel?'
       var cancelDialogContent = 'Your preferences have not been saved. By continuing to use our website, you՚re agreeing to our Website Data Collection Policy.'
-
+      
       return {
         container: '#consent-manager',
         writeKey: 'mA3XTMcavCUOQo5DL56VIHWcJMsyhAI7',
@@ -97,40 +97,9 @@
         translationMessages: {
           'ui.save': 'Save',
           'ui.cancel': 'Cancel',
-          'ui.yes': 'Yes',
-          'ui.no': 'No',
-          'ui.not_available': 'N/A',
-          'ui.go_back': 'Go Back',
-          'ui.yes_cancel': 'Yes, Cancel',
-          'ui.header.allow': 'Allow',
-          'ui.header.category': 'Category',
-          'ui.header.purpose': 'Purpose',
-          'ui.header.tools': 'Tools',
-          'aria.functional.allow': 'Allow functional tracking',
-          'aria.functional.disallow': 'Disallow functional tracking',
-          'aria.marketing.allow': 'Allow marketing and analytics tracking',
-          'aria.marketing.disallow': 'Disallow marketing and analytics tracking',
-          'aria.advertising.allow': 'Allow advertising tracking',
-          'aria.advertising.disallow': 'Disallow advertising tracking',
-          'category.functional': 'Functional',
-          'category.marketing': 'Marketing and Analytics',
-          'category.advertising': 'Advertising',
-          'category.essential': 'Essential',
           'purpose.functional': [
             React.createElement('p', null, 'To monitor the performance of our site and to enhance your browsing experience.'),
             React.createElement('p', null, 'For example, these tools enable you to communicate with us via live chat.')
-          ],
-          'purpose.marketing': [
-            React.createElement('p', null, 'To understand user behavior in order to provide you with a more relevant browsing experience or personalize the content on our site.'),
-            React.createElement('p', null, 'For example, we collect information about which pages you visit to help us present more relevant information.')
-          ],
-          'purpose.advertising': [
-            React.createElement('p', null, 'We use browser cookies that are necessary for the site to work as intended.'),
-            React.createElement('p', null, 'For example, we may serve you a personalized ad based on the pages you visit on our site.')
-          ],
-          'purpose.essential': [
-            React.createElement('p', null, 'To personalize and measure the effectiveness of advertising on our site and other websites.'),
-            React.createElement('p', null, 'For example, we store your website data collection preferences so we can honor them if you return to our site. You can disable these cookies in your browser settings but if you do the site may not work as intended.')
           ]
         }
       }

--- a/tools/standalone.html
+++ b/tools/standalone.html
@@ -67,12 +67,77 @@
     }();
   </script>
 
-  <script src="https://unpkg.com/@segment/consent-manager@1.2.0/standalone/consent-manager.js" integrity="sha256-N/iVJLiB/wC00Ta5lCOuOSL3dT3NF9tb9roS8uxTPGQ2Iqe70cqo="
-    crossorigin="anonymous" defer data-container="#consent-manager" data-writeKey="mA3XTMcavCUOQo5DL56VIHWcJMsyhAI7"
-    data-otherWriteKeys="vMRS7xbsjH97Bb2PeKbEKvYDvgMm5T3l" data-bannerContent="We use cookies (and other similar technologies) to collect data to improve your experience on our site."
-    data-bannerSubContent="You can change your preferences at any time." data-preferencesDialogTitle="Website Data Collection Preferences"
-    data-preferencesDialogContent="We use data collected by cookies and JavaScript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site."
-    data-cancelDialogTitle="Are you sure you want to cancel?" data-cancelDialogContent="Your preferences have not been saved. By continuing to use our website, you're agreeing to our Website Data Collection Policy"></script>
+  <script>
+    window.consentManagerConfig = function(exports) {
+      var React = exports.React
+      var inEU = exports.inEU
+
+      var bannerContent = React.createElement(
+      'span',
+      null,
+      'We use cookies (and other similar technologies) to collect data to improve your experience on our site.')
+      var bannerSubContent = 'You can change your preferences at any time.'
+      var preferencesDialogTitle = 'Website Data Collection Preferences'
+      var preferencesDialogContent = 'We use data collected by cookies and JavaScript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site.'
+      var cancelDialogTitle = 'Are you sure you want to cancel?'
+      var cancelDialogContent = 'Your preferences have not been saved. By continuing to use our website, you՚re agreeing to our Website Data Collection Policy.'
+
+      return {
+        container: '#consent-manager',
+        writeKey: 'mA3XTMcavCUOQo5DL56VIHWcJMsyhAI7',
+        otherWriteKeys: 'vMRS7xbsjH97Bb2PeKbEKvYDvgMm5T3l',
+        implyConsentOnInteraction: false,
+        shouldRequireConsent: inEU,
+        bannerContent: bannerContent,
+        bannerSubContent: bannerSubContent,
+        preferencesDialogTitle: preferencesDialogTitle,
+        preferencesDialogContent: preferencesDialogContent,
+        cancelDialogTitle: cancelDialogTitle,
+        cancelDialogContent: cancelDialogContent,
+        translationMessages: {
+          'ui.save': 'Save',
+          'ui.cancel': 'Cancel',
+          'ui.yes': 'Yes',
+          'ui.no': 'No',
+          'ui.not_available': 'N/A',
+          'ui.go_back': 'Go Back',
+          'ui.yes_cancel': 'Yes, Cancel',
+          'ui.header.allow': 'Allow',
+          'ui.header.category': 'Category',
+          'ui.header.purpose': 'Purpose',
+          'ui.header.tools': 'Tools',
+          'aria.functional.allow': 'Allow functional tracking',
+          'aria.functional.disallow': 'Disallow functional tracking',
+          'aria.marketing.allow': 'Allow marketing and analytics tracking',
+          'aria.marketing.disallow': 'Disallow marketing and analytics tracking',
+          'aria.advertising.allow': 'Allow advertising tracking',
+          'aria.advertising.disallow': 'Disallow advertising tracking',
+          'category.functional': 'Functional',
+          'category.marketing': 'Marketing and Analytics',
+          'category.advertising': 'Advertising',
+          'category.essential': 'Essential',
+          'purpose.functional': [
+            React.createElement('p', null, 'To monitor the performance of our site and to enhance your browsing experience.'),
+            React.createElement('p', null, 'For example, these tools enable you to communicate with us via live chat.')
+          ],
+          'purpose.marketing': [
+            React.createElement('p', null, 'To understand user behavior in order to provide you with a more relevant browsing experience or personalize the content on our site.'),
+            React.createElement('p', null, 'For example, we collect information about which pages you visit to help us present more relevant information.')
+          ],
+          'purpose.advertising': [
+            React.createElement('p', null, 'We use browser cookies that are necessary for the site to work as intended.'),
+            React.createElement('p', null, 'For example, we may serve you a personalized ad based on the pages you visit on our site.')
+          ],
+          'purpose.essential': [
+            React.createElement('p', null, 'To personalize and measure the effectiveness of advertising on our site and other websites.'),
+            React.createElement('p', null, 'For example, we store your website data collection preferences so we can honor them if you return to our site. You can disable these cookies in your browser settings but if you do the site may not work as intended.')
+          ]
+        }
+      }
+    }
+  </script>
+
+  <script src="/standalone/consent-manager.js" crossorigin="anonymous" defer></script>
 </body>
 
 </html>


### PR DESCRIPTION
Hi, we are using your library in [Zava](https://www.zavamed.com/uk/). We found it very useful as we are using Segment, but we had requirement to customise all the text messages inside consent manager. We have website in multiple languages German, French, English. So, we've added support to customise any text in UI of consent-manager. 

I've added additional parameter `translationMessages` in the list of options to configure `consent-manager`. I didn't move `bannerContent` and other options into it to avoid braking changes. That can be joined together in major update. I'm providing fallback messages in file `default-messages.js`.

What do you think? Would you consider adding localisation support to consent-manager?