### PR TITLE
Take window.analytics as a component prop

### DIFF
--- a/src/consent-manager-builder/analytics.js
+++ b/src/consent-manager-builder/analytics.js
@@ -1,4 +1,5 @@
 export default function conditionallyLoadAnalytics({
+  analyticsLibrary,
   writeKey,
   destinations,
   destinationPreferences,
@@ -14,8 +15,8 @@ export default function conditionallyLoadAnalytics({
     }
 
     // Load a.js normally when consent isn't required and there's no preferences
-    if (!window.analytics.initialized) {
-      window.analytics.load(writeKey)
+    if (!analyticsLibrary.initialized) {
+      analyticsLibrary.load(writeKey)
     }
     return
   }
@@ -30,7 +31,7 @@ export default function conditionallyLoadAnalytics({
 
   // Reload the page if the trackers have already been initialised so that
   // the user's new preferences can take affect
-  if (window.analytics.initialized) {
+  if (analyticsLibrary.initialized) {
     if (shouldReload) {
       window.location.reload()
     }
@@ -39,6 +40,6 @@ export default function conditionallyLoadAnalytics({
 
   // Don't load a.js at all if nothing has been enabled
   if (isAnythingEnabled) {
-    window.analytics.load(writeKey, {integrations})
+    analyticsLibrary.load(writeKey, {integrations})
   }
 }

--- a/src/consent-manager-builder/index.js
+++ b/src/consent-manager-builder/index.js
@@ -93,6 +93,7 @@ export default class ConsentManagerBuilder extends Component {
 
   initialise = async () => {
     const {
+      analyticsLibrary,
       writeKey,
       otherWriteKeys,
       shouldRequireConsent,
@@ -113,6 +114,7 @@ export default class ConsentManagerBuilder extends Component {
     )
 
     conditionallyLoadAnalytics({
+      analyticsLibrary,
       writeKey,
       destinations,
       destinationPreferences,

--- a/src/consent-manager-builder/index.js
+++ b/src/consent-manager-builder/index.js
@@ -162,7 +162,12 @@ export default class ConsentManagerBuilder extends Component {
   }
 
   handleSaveConsent = (newPreferences, shouldReload) => {
-    const {analyticsLibrary, writeKey, cookieDomain, mapCustomPreferences} = this.props
+    const {
+      analyticsLibrary,
+      writeKey,
+      cookieDomain,
+      mapCustomPreferences
+    } = this.props
 
     this.setState(prevState => {
       const {
@@ -200,7 +205,12 @@ export default class ConsentManagerBuilder extends Component {
         destinationPreferences
       )
 
-      savePreferences({analyticsLibrary, destinationPreferences, customPreferences, cookieDomain})
+      savePreferences({
+        analyticsLibrary,
+        destinationPreferences,
+        customPreferences,
+        cookieDomain
+      })
       conditionallyLoadAnalytics({
         analyticsLibrary,
         writeKey,

--- a/src/consent-manager-builder/index.js
+++ b/src/consent-manager-builder/index.js
@@ -31,6 +31,7 @@ export default class ConsentManagerBuilder extends Component {
     otherWriteKeys: PropTypes.arrayOf(PropTypes.string),
     shouldRequireConsent: PropTypes.func,
     initialPreferences: PropTypes.object,
+    analyticsLibrary: PropTypes.object.isRequired,
     mapCustomPreferences: PropTypes.func,
     cookieDomain: PropTypes.string
   }
@@ -161,7 +162,7 @@ export default class ConsentManagerBuilder extends Component {
   }
 
   handleSaveConsent = (newPreferences, shouldReload) => {
-    const {writeKey, cookieDomain, mapCustomPreferences} = this.props
+    const {analyticsLibrary, writeKey, cookieDomain, mapCustomPreferences} = this.props
 
     this.setState(prevState => {
       const {
@@ -199,8 +200,9 @@ export default class ConsentManagerBuilder extends Component {
         destinationPreferences
       )
 
-      savePreferences({destinationPreferences, customPreferences, cookieDomain})
+      savePreferences({analyticsLibrary, destinationPreferences, customPreferences, cookieDomain})
       conditionallyLoadAnalytics({
+        analyticsLibrary,
         writeKey,
         destinations,
         destinationPreferences,

--- a/src/consent-manager-builder/preferences.js
+++ b/src/consent-manager-builder/preferences.js
@@ -20,11 +20,12 @@ export function loadPreferences() {
 }
 
 export function savePreferences({
+  analyticsLibrary,
   destinationPreferences,
   customPreferences,
   cookieDomain
 }) {
-  window.analytics.identify({
+  analyticsLibrary.identify({
     destinationTrackingPreferences: destinationPreferences,
     customTrackingPreferences: customPreferences
   })

--- a/src/consent-manager/index.js
+++ b/src/consent-manager/index.js
@@ -28,7 +28,7 @@ export default class ConsentManager extends PureComponent {
     onError: PropTypes.func,
     cancelDialogTitle: PropTypes.node,
     cancelDialogContent: PropTypes.node.isRequired,
-    analyticsLibrary: PropTypes.object,
+    analyticsLibrary: PropTypes.object
   }
 
   static defaultProps = {
@@ -42,7 +42,7 @@ export default class ConsentManager extends PureComponent {
     bannerBackgroundColor: '#1f4160',
     preferencesDialogTitle: 'Website Data Collection Preferences',
     cancelDialogTitle: 'Are you sure you want to cancel?',
-    analyticsLibrary: window.analytics,
+    analyticsLibrary: window.analytics
   }
 
   render() {

--- a/src/consent-manager/index.js
+++ b/src/consent-manager/index.js
@@ -27,7 +27,8 @@ export default class ConsentManager extends PureComponent {
     preferencesDialogContent: PropTypes.node.isRequired,
     onError: PropTypes.func,
     cancelDialogTitle: PropTypes.node,
-    cancelDialogContent: PropTypes.node.isRequired
+    cancelDialogContent: PropTypes.node.isRequired,
+    analyticsLibrary: PropTypes.object,
   }
 
   static defaultProps = {
@@ -40,7 +41,8 @@ export default class ConsentManager extends PureComponent {
     bannerSubContent: 'You can change your preferences at any time.',
     bannerBackgroundColor: '#1f4160',
     preferencesDialogTitle: 'Website Data Collection Preferences',
-    cancelDialogTitle: 'Are you sure you want to cancel?'
+    cancelDialogTitle: 'Are you sure you want to cancel?',
+    analyticsLibrary: window.analytics,
   }
 
   render() {
@@ -58,6 +60,7 @@ export default class ConsentManager extends PureComponent {
       preferencesDialogContent,
       cancelDialogTitle,
       cancelDialogContent,
+      analyticsLibrary,
       onError
     } = this.props
 
@@ -69,6 +72,7 @@ export default class ConsentManager extends PureComponent {
         shouldRequireConsent={shouldRequireConsent}
         cookieDomain={cookieDomain}
         initialPreferences={initialPreferences}
+        analyticsLibrary={analyticsLibrary}
         mapCustomPreferences={this.handleMapCustomPreferences}
       >
         {({

--- a/src/consent-manager/index.js
+++ b/src/consent-manager/index.js
@@ -28,7 +28,7 @@ export default class ConsentManager extends PureComponent {
     onError: PropTypes.func,
     cancelDialogTitle: PropTypes.node,
     cancelDialogContent: PropTypes.node.isRequired,
-    analyticsLibrary: PropTypes.object
+    analyticsLibrary: PropTypes.object.isRequired
   }
 
   static defaultProps = {
@@ -41,8 +41,7 @@ export default class ConsentManager extends PureComponent {
     bannerSubContent: 'You can change your preferences at any time.',
     bannerBackgroundColor: '#1f4160',
     preferencesDialogTitle: 'Website Data Collection Preferences',
-    cancelDialogTitle: 'Are you sure you want to cancel?',
-    analyticsLibrary: window.analytics
+    cancelDialogTitle: 'Are you sure you want to cancel?'
   }
 
   render() {

--- a/src/consent-manager/index.js
+++ b/src/consent-manager/index.js
@@ -28,6 +28,7 @@ export default class ConsentManager extends PureComponent {
     onError: PropTypes.func,
     cancelDialogTitle: PropTypes.node,
     cancelDialogContent: PropTypes.node.isRequired,
+    // TODO default this to window.analytics?
     analyticsLibrary: PropTypes.object.isRequired
   }
 

--- a/test/consent-manager-builder/analytics.js
+++ b/test/consent-manager-builder/analytics.js
@@ -8,7 +8,7 @@ test.beforeEach(() => {
 
 test.serial('loads analytics.js with preferences', t => {
   const ajsLoad = sinon.spy()
-  global.window.analytics = {load: ajsLoad}
+  const analyticsLibrary = {load: ajsLoad}
   const writeKey = '123'
   const destinations = [{id: 'Amplitude'}]
   const destinationPreferences = {
@@ -16,6 +16,7 @@ test.serial('loads analytics.js with preferences', t => {
   }
 
   conditionallyLoadAnalytics({
+    analyticsLibrary,
     writeKey,
     destinations,
     destinationPreferences,
@@ -35,12 +36,13 @@ test.serial('loads analytics.js with preferences', t => {
 
 test.serial('doesn՚t load analytics.js when there are no preferences', t => {
   const ajsLoad = sinon.spy()
-  global.window.analytics = {load: ajsLoad}
+  const analyticsLibrary = {load: ajsLoad}
   const writeKey = '123'
   const destinations = [{id: 'Amplitude'}]
   const destinationPreferences = null
 
   conditionallyLoadAnalytics({
+    analyticsLibrary,
     writeKey,
     destinations,
     destinationPreferences,
@@ -52,7 +54,7 @@ test.serial('doesn՚t load analytics.js when there are no preferences', t => {
 
 test.serial('doesn՚t load analytics.js when all preferences are false', t => {
   const ajsLoad = sinon.spy()
-  global.window.analytics = {load: ajsLoad}
+  const analyticsLibrary = {load: ajsLoad}
   const writeKey = '123'
   const destinations = [{id: 'Amplitude'}]
   const destinationPreferences = {
@@ -60,6 +62,7 @@ test.serial('doesn՚t load analytics.js when all preferences are false', t => {
   }
 
   conditionallyLoadAnalytics({
+    analyticsLibrary,
     writeKey,
     destinations,
     destinationPreferences,
@@ -73,7 +76,7 @@ test.serial(
   'reloads the page when analytics.js has already been initialised',
   t => {
     const reload = sinon.spy()
-    global.window.analytics = {
+    const analyticsLibrary = {
       load() {
         this.initialized = true
       }
@@ -86,12 +89,14 @@ test.serial(
     }
 
     conditionallyLoadAnalytics({
+      analyticsLibrary,
       writeKey,
       destinations,
       destinationPreferences,
       isConsentRequired: true
     })
     conditionallyLoadAnalytics({
+      analyticsLibrary,
       writeKey,
       destinations,
       destinationPreferences,
@@ -104,7 +109,7 @@ test.serial(
 
 test.serial('should allow the reload behvaiour to be disabled', t => {
   const reload = sinon.spy()
-  global.window.analytics = {
+  const analyticsLibrary = {
     load() {
       this.initialized = true
     }
@@ -117,12 +122,14 @@ test.serial('should allow the reload behvaiour to be disabled', t => {
   }
 
   conditionallyLoadAnalytics({
+    analyticsLibrary,
     writeKey,
     destinations,
     destinationPreferences,
     isConsentRequired: true
   })
   conditionallyLoadAnalytics({
+    analyticsLibrary,
     writeKey,
     destinations,
     destinationPreferences,
@@ -135,12 +142,13 @@ test.serial('should allow the reload behvaiour to be disabled', t => {
 
 test.serial('loads analytics.js normally when consent isn՚t required', t => {
   const ajsLoad = sinon.spy()
-  global.window.analytics = {load: ajsLoad}
+  const analyticsLibrary = {load: ajsLoad}
   const writeKey = '123'
   const destinations = [{id: 'Amplitude'}]
   const destinationPreferences = null
 
   conditionallyLoadAnalytics({
+    analyticsLibrary,
     writeKey,
     destinations,
     destinationPreferences,
@@ -154,7 +162,7 @@ test.serial('loads analytics.js normally when consent isn՚t required', t => {
 
 test.serial('still applies preferences when consent isn՚t required', t => {
   const ajsLoad = sinon.spy()
-  global.window.analytics = {load: ajsLoad}
+  const analyticsLibrary = {load: ajsLoad}
   const writeKey = '123'
   const destinations = [{id: 'Amplitude'}]
   const destinationPreferences = {
@@ -162,6 +170,7 @@ test.serial('still applies preferences when consent isn՚t required', t => {
   }
 
   conditionallyLoadAnalytics({
+    analyticsLibrary,
     writeKey,
     destinations,
     destinationPreferences,

--- a/test/consent-manager-builder/index.js
+++ b/test/consent-manager-builder/index.js
@@ -59,7 +59,7 @@ test.cb.serial('provides a list of enabled destinations', t => {
 test.cb.serial('provides a list of newly added destinations', t => {
   global.document.cookie =
     'tracking-preferences={%22version%22:1%2C%22destinations%22:{%22Amplitude%22:true}}'
-  global.window.analytics = {load() {}}
+  const analyticsLibrary = {load() {}}
 
   nock('https://cdn.segment.com')
     .get('/v1/projects/123/integrations')
@@ -75,7 +75,7 @@ test.cb.serial('provides a list of newly added destinations', t => {
     ])
 
   shallow(
-    <ConsentManagerBuilder writeKey="123">
+    <ConsentManagerBuilder writeKey="123" analyticsLibrary={analyticsLibrary}>
       {({newDestinations}) => {
         t.deepEqual(newDestinations, [
           {
@@ -93,7 +93,7 @@ test.cb.serial('loads analytics.js with the user՚s preferences', t => {
   const ajsLoad = sinon.spy()
   global.document.cookie =
     'tracking-preferences={%22version%22:1%2C%22destinations%22:{%22Amplitude%22:true}}'
-  global.window.analytics = {load: ajsLoad}
+  const analyticsLibrary = {load: ajsLoad}
   const writeKey = '123'
 
   nock('https://cdn.segment.com')
@@ -106,7 +106,10 @@ test.cb.serial('loads analytics.js with the user՚s preferences', t => {
     ])
 
   shallow(
-    <ConsentManagerBuilder writeKey={writeKey}>
+    <ConsentManagerBuilder
+      writeKey={writeKey}
+      analyticsLibrary={analyticsLibrary}
+    >
       {() => {
         t.true(ajsLoad.calledOnce)
         t.is(ajsLoad.args[0][0], writeKey)
@@ -126,7 +129,7 @@ test.cb.serial('loads analytics.js with the user՚s preferences', t => {
 test.cb.serial('provides an object containing the WIP preferences', t => {
   global.document.cookie =
     'tracking-preferences={%22version%22:1%2C%22destinations%22:{%22Amplitude%22:true}}'
-  global.window.analytics = {load() {}}
+  const analyticsLibrary = {load() {}}
 
   nock('https://cdn.segment.com')
     .get('/v1/projects/123/integrations')
@@ -138,7 +141,7 @@ test.cb.serial('provides an object containing the WIP preferences', t => {
     ])
 
   shallow(
-    <ConsentManagerBuilder writeKey="123">
+    <ConsentManagerBuilder writeKey="123" analyticsLibrary={analyticsLibrary}>
       {({preferences}) => {
         t.deepEqual(preferences, {
           Amplitude: true

--- a/test/consent-manager-builder/preferences.js
+++ b/test/consent-manager-builder/preferences.js
@@ -37,7 +37,7 @@ test.serial('loadPreferences() returns preferences when cookie exists', t => {
 
 test.serial('savePreferences() saves the preferences', t => {
   const ajsIdentify = sinon.spy()
-  global.window.analytics = {identify: ajsIdentify}
+  const analyticsLibrary = {identify: ajsIdentify}
   global.document.cookie = ''
   const destinationPreferences = {
     Amplitude: true
@@ -47,6 +47,7 @@ test.serial('savePreferences() saves the preferences', t => {
   }
 
   savePreferences({
+    analyticsLibrary,
     destinationPreferences,
     customPreferences
   })
@@ -66,13 +67,14 @@ test.serial('savePreferences() saves the preferences', t => {
 
 test.serial('savePreferences() sets the cookie domain', t => {
   const ajsIdentify = sinon.spy()
-  global.window.analytics = {identify: ajsIdentify}
+  const analyticsLibrary = {identify: ajsIdentify}
   global.document.cookie = ''
   const destinationPreferences = {
     Amplitude: true
   }
 
   savePreferences({
+    analyticsLibrary,
     destinationPreferences,
     cookieDomain: 'example.com'
   })


### PR DESCRIPTION
Sorry if this is poorly formatted or anything. My initial intent here is to just validate the approach and/or make sure there isn't a better way to achieve my goal.

## Problem

I create and manage a web service that allows users to create their own websites. Part of this is allowing them to edit their _live_ site using our tools. 

While editing their live site, we keep our own metrics on the tools they're using. However a recent problem we've come across is that some users also have their own deployment of `analytics.js` which overloads the `window.analytics` object. So now we are sending _our_ metrics to their analytics.

## Solution

I wrote this up real quick to take the analytics library as a parameter. By doing so, this would allow us to load `analytics.js` with some minor edits, eg, loading to `window.ourAnalytics` instead of `window.analytics` (or possibly not to a global at all). Then we can just pass that prop to `ConsentManager` as `analyticsLibrary={window.ourAnalytics}`.

## Feedback

- thoughts, tips, suggestions?
- as mentioned, this was pretty quick and haphazard, but just wanted to validate the idea with you lot. noticed in the tests that i made a bit of a mess, however, i don't want to invest more time in this at the moment until it sounds like the approach works for everyone.