### PR TITLE
Add new `closeBehavior` option to Consent Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,19 @@ Default: `() => true`
 
 Callback function that determines if consent is required before tracking can begin. Return `true` to show the consent banner and wait for consent (if no consent has been given yet). Return `false` to not show the consent banner and start tracking immediately (unless the user has opted out). The function can return a `Promise` that resolves to a boolean.
 
+##### closeBehavior
+
+Type: `enum|string`<br>
+Default: `dismiss`
+
+An option to determine what should be the default behavior for the `x` button on the consent manager banner.
+
+Options:
+
+- `dismiss` (default) - Dismisses the banner, but don't save or change any preferences. Analytics.js won't be loaded until explicit consent is given.
+- `accept` - Assume consent across every category.
+- `deny` - Denies consent across every category.
+
 ##### implyConsentOnInteraction
 
 **_ Breaking Change _** (versions < 3.0.0 will default this option `true`)

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "jest src/__tests__",
     "prepublishOnly": "yarn run clean && yarn run build",
     "postpublish": "yarn build-storybook && yarn deploy-storybook -- --existing-output-dir=storybook-static",
-    "dev": "yarn build-standalone --watch && start-storybook -s ./ -p 9009",
+    "dev": "concurrently 'yarn build-standalone --watch' 'yarn start-storybook -s ./ -p 9009'",
     "build-commonjs": "tsc --outDir commonjs --inlineSourceMap",
     "build-esm": "tsc --module es2015 --outDir esm --inlineSourceMap",
     "build-standalone": "webpack",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "jest src/__tests__",
     "prepublishOnly": "yarn run clean && yarn run build",
     "postpublish": "yarn build-storybook && yarn deploy-storybook -- --existing-output-dir=storybook-static",
-    "dev": "yarn build-standalone && start-storybook -s ./ -p 9009",
+    "dev": "yarn build-standalone --watch && start-storybook -s ./ -p 9009",
     "build-commonjs": "tsc --outDir commonjs --inlineSourceMap",
     "build-esm": "tsc --module es2015 --outDir esm --inlineSourceMap",
     "build-standalone": "webpack",

--- a/src/consent-manager-builder/preferences.ts
+++ b/src/consent-manager-builder/preferences.ts
@@ -2,11 +2,14 @@
 import cookies from 'js-cookie'
 import topDomain from '@segment/top-domain'
 import { WindowWithAJS, Preferences, CategoryPreferences } from '../types'
+import { EventEmitter } from 'events'
 
 const COOKIE_KEY = 'tracking-preferences'
+// TODO: Make cookie expiration configurable
 const COOKIE_EXPIRES = 365
 
 // TODO: harden against invalid cookies
+// TODO: harden against different versions of cookies
 export function loadPreferences(): Preferences {
   const preferences = cookies.getJSON(COOKIE_KEY)
 
@@ -21,6 +24,19 @@ export function loadPreferences(): Preferences {
 }
 
 type SavePreferences = Preferences & { cookieDomain?: string }
+
+const emitter = new EventEmitter()
+
+/**
+ * Subscribes to consent preferences changing over time and returns
+ * a cleanup function that can be invoked to remove the instantiated listener.
+ *
+ * @param listener a function to be invoked when ConsentPreferences are saved
+ */
+export function onPreferencesSaved(listener: (prefs: Preferences) => void) {
+  emitter.on('preferencesSaved', listener)
+  return () => emitter.off('preferencesSaved', listener)
+}
 
 export function savePreferences({
   destinationPreferences,
@@ -46,5 +62,10 @@ export function savePreferences({
   cookies.set(COOKIE_KEY, value, {
     expires: COOKIE_EXPIRES,
     domain
+  })
+
+  emitter.emit('preferencesSaved', {
+    destinationPreferences,
+    customPreferences
   })
 }

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -71,6 +71,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
             setPreferences={setPreferences}
             resetPreferences={resetPreferences}
             saveConsent={saveConsent}
+            closeBehavior={this.props.closeBehavior}
             implyConsentOnInteraction={implyConsentOnInteraction ?? ConsentManager.defaultProps.implyConsentOnInteraction}
             bannerContent={bannerContent}
             bannerSubContent={bannerSubContent}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import CMB from './consent-manager-builder'
 import CM from './consent-manager'
 
 export { openDialog as openConsentManager } from './consent-manager/container'
+export { loadPreferences, savePreferences } from './consent-manager-builder/preferences'
 export const ConsentManagerBuilder = CMB
 export const ConsentManager = CM
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,12 @@ import CMB from './consent-manager-builder'
 import CM from './consent-manager'
 
 export { openDialog as openConsentManager } from './consent-manager/container'
-export { loadPreferences, savePreferences } from './consent-manager-builder/preferences'
+export {
+  loadPreferences,
+  savePreferences,
+  onPreferencesSaved
+} from './consent-manager-builder/preferences'
+
 export const ConsentManagerBuilder = CMB
 export const ConsentManager = CM
 

--- a/src/standalone.tsx
+++ b/src/standalone.tsx
@@ -3,11 +3,13 @@ import ReactDOM from 'react-dom'
 import inEU from '@segment/in-eu'
 import { ConsentManager, openConsentManager, doNotTrack } from '.'
 import { ConsentManagerProps, WindowWithConsentManagerConfig, ConsentManagerInput } from './types'
+import { CloseBehavior } from './consent-manager/container'
 
 export const version = process.env.VERSION
 export { openConsentManager, doNotTrack, inEU }
 
 const dataset = document.currentScript && document.currentScript.dataset
+// TODO: define string based input type that can be parsed to `ConsentManagerInput`
 let props: Partial<ConsentManagerInput> = {}
 let containerRef: string | undefined
 
@@ -42,6 +44,8 @@ if (localWindow.consentManagerConfig) {
   props.preferencesDialogContent = dataset.preferencesdialogcontent
   props.cancelDialogTitle = dataset.canceldialogtitle
   props.cancelDialogContent = dataset.canceldialogcontent
+  // @ts-ignore
+  props.closeBehavior = dataset.closebehavior
 }
 
 if (!containerRef) {
@@ -70,6 +74,17 @@ if (typeof props.otherWriteKeys === 'string') {
 
 if (typeof props.implyConsentOnInteraction === 'string') {
   props.implyConsentOnInteraction = props.implyConsentOnInteraction === 'true'
+}
+
+if (props.closeBehavior !== undefined && typeof props.closeBehavior === 'string') {
+  const options = [
+    CloseBehavior.ACCEPT.toString(),
+    CloseBehavior.DENY.toString(),
+    CloseBehavior.DISMISS.toString()
+  ]
+  if (!options.includes(props.closeBehavior)) {
+    throw new Error(`ConsentManager: closeBehavior should be one of ${options}`)
+  }
 }
 
 const container = document.querySelector(containerRef)

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ export type WindowWithConsentManagerConfig = Window &
     ) => Partial<ConsentManagerInput> | Partial<ConsentManagerInput>
   }
 
-export interface ConsentManagerInput extends ConsentManagerProps {
+export type ConsentManagerInput = ConsentManagerProps & {
   container: string
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { CloseBehavior } from './consent-manager/container'
+
 type AJS = SegmentAnalytics.AnalyticsJS & {
   initialized: boolean
 }
@@ -62,4 +64,5 @@ export interface ConsentManagerProps {
   onError?: (error: Error | undefined) => void
   cancelDialogTitle?: React.ReactNode
   cancelDialogContent: React.ReactNode
+  closeBehavior?: CloseBehavior
 }

--- a/stories/0-consent-manager.stories.tsx
+++ b/stories/0-consent-manager.stories.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import cookies from 'js-cookie'
 import { Pane, Heading, Button } from 'evergreen-ui'
-import { ConsentManager, openConsentManager, loadPreferences } from '../src'
+import { ConsentManager, openConsentManager, loadPreferences, onPreferencesSaved } from '../src'
 import { storiesOf } from '@storybook/react'
 import { CloseBehavior } from '../src/consent-manager/container'
 import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs'
 import SyntaxHighlighter from 'react-syntax-highlighter'
+import { Preferences } from '../src/types'
 
 const bannerContent = (
   <span>
@@ -63,6 +64,18 @@ const cancelDialogContent = (
 )
 
 const ConsentManagerExample = (props: { closeBehavior: CloseBehavior }) => {
+  const [prefs, updatePrefs] = React.useState<Preferences>(loadPreferences())
+
+  const cleanup = onPreferencesSaved(preferences => {
+    updatePrefs(preferences)
+  })
+
+  React.useEffect(() => {
+    return () => {
+      cleanup()
+    }
+  })
+
   return (
     <Pane>
       <ConsentManager
@@ -99,7 +112,7 @@ const ConsentManagerExample = (props: { closeBehavior: CloseBehavior }) => {
           <div>
             <Heading>Current Preferences</Heading>
             <SyntaxHighlighter language="json" style={docco}>
-              {JSON.stringify(loadPreferences(), null, 2)}
+              {JSON.stringify(prefs, null, 2)}
             </SyntaxHighlighter>
           </div>
           <Button marginRight={20} onClick={openConsentManager}>

--- a/stories/0.1-consent-manager-close-interaction.stories.tsx
+++ b/stories/0.1-consent-manager-close-interaction.stories.tsx
@@ -1,11 +1,9 @@
 import React from 'react'
 import cookies from 'js-cookie'
 import { Pane, Heading, Button } from 'evergreen-ui'
-import { ConsentManager, openConsentManager, loadPreferences } from '../src'
+import { ConsentManager, openConsentManager } from '../src'
 import { storiesOf } from '@storybook/react'
-import { CloseBehavior } from '../src/consent-manager/container'
-import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs'
-import SyntaxHighlighter from 'react-syntax-highlighter'
+import { ImplyConsentOnInteraction } from './ImplyConsentOnInteraction'
 
 const bannerContent = (
   <span>
@@ -62,7 +60,7 @@ const cancelDialogContent = (
   </div>
 )
 
-const ConsentManagerExample = (props: { closeBehavior: CloseBehavior }) => {
+const ConsentManagerExample = () => {
   return (
     <Pane>
       <ConsentManager
@@ -74,7 +72,6 @@ const ConsentManagerExample = (props: { closeBehavior: CloseBehavior }) => {
         preferencesDialogContent={preferencesDialogContent}
         cancelDialogTitle={cancelDialogTitle}
         cancelDialogContent={cancelDialogContent}
-        closeBehavior={props.closeBehavior}
       />
 
       <Pane marginX={100} marginTop={20}>
@@ -96,22 +93,18 @@ const ConsentManagerExample = (props: { closeBehavior: CloseBehavior }) => {
         </Pane>
 
         <p>
-          <div>
-            <Heading>Current Preferences</Heading>
-            <SyntaxHighlighter language="json" style={docco}>
-              {JSON.stringify(loadPreferences(), null, 2)}
-            </SyntaxHighlighter>
-          </div>
-          <Button marginRight={20} onClick={openConsentManager}>
-            Change Cookie Preferences
-          </Button>
+          <Button onClick={openConsentManager}>Data Collection and Cookie Preferences</Button>
+        </p>
+
+        <p>
+          <Heading>to see the banner again:</Heading>
           <Button
             onClick={() => {
               cookies.remove('tracking-preferences')
               window.location.reload()
             }}
           >
-            Clear
+            Clear tracking preferences cookie
           </Button>
         </p>
       </Pane>
@@ -119,7 +112,6 @@ const ConsentManagerExample = (props: { closeBehavior: CloseBehavior }) => {
   )
 }
 
-storiesOf('React Component / OnClose interactions', module)
-  .add(`Dismiss`, () => <ConsentManagerExample closeBehavior={CloseBehavior.DISMISS} />)
-  .add(`Accept`, () => <ConsentManagerExample closeBehavior={CloseBehavior.ACCEPT} />)
-  .add(`Deny`, () => <ConsentManagerExample closeBehavior={CloseBehavior.DENY} />)
+storiesOf('React Component / Basics', module)
+  .add(`Basic React Component`, () => <ConsentManagerExample />)
+  .add(`Basic React Component with implied consent`, () => <ImplyConsentOnInteraction />)

--- a/stories/standalone.html
+++ b/stories/standalone.html
@@ -24,6 +24,7 @@
       data-preferencesDialogContent="We use data collected by cookies and JavaScript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site."
       data-cancelDialogTitle="Are you sure you want to cancel?"
       data-cancelDialogContent="Your preferences have not been saved. By continuing to use our website, you're agreeing to our Website Data Collection Policy"
+      data-closeBehavior="accept"
     ></script>
 
     <!-- Load analytics.js -->


### PR DESCRIPTION
## What this PR does
- Adds a new `closeBehavior` option to allow for developers to choose what's the default behavior for the `x` button.

### Demo
[demo](http://g.recordit.co/WH6iz1Fbst.gif)

### From the Docs:

##### closeBehavior

Type: `enum|string`<br>
Default: `dismiss`

An option to determine what should be the default behavior for the `x` button on the consent manager banner.

Options:

- `dismiss` (default) - Dismisses the banner, but don't save or change any preferences. Analytics.js won't be loaded until explicit consent is given.
- `accept` - Assume consent across every category.
- `deny` - Denies consent across every category.