### PR TITLE
Deprecate data attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,27 +69,6 @@ The following global variables are also exposed:
 - `consentManager.doNotTrack()` - Utility function that returns the user's Do Not Track preference (normalises the cross browser API differences). Returns `true`, `false` or `null` (no preference specified).
 - `consentManager.inEU()` - The [@segment/in-eu][ineu] `inEU()` function.
 
-#### Data Attributes
-
-The `shouldRequireConsent` option isn't supported and the `otherWriteKeys` option should be a comma separated list.
-
-_Note: the data attributes [won't work in Internet Explorer][currentscript] (Edge works fine though)._
-
-```html
-<script
-  src="https://unpkg.com/@segment/consent-manager@3.0.0/standalone/consent-manager.js"
-  defer
-  data-container="#target-container"
-  data-writeKey="<your-segment-write-key>"
-  data-bannerContent="We use cookies (and other similar technologies) to collect data to improve your experience on our site."
-  data-bannerSubContent="You can change your preferences at any time."
-  data-preferencesDialogTitle="Website Data Collection Preferences"
-  data-preferencesDialogContent="We use data collected by cookies and JavaScript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site."
-  data-cancelDialogTitle="Are you sure you want to cancel?"
-  data-cancelDialogContent="Your preferences have not been saved. By continuing to use our website, you՚re agreeing to our Website Data Collection Policy."
-></script>
-```
-
 #### Callback Function
 
 All the options are supported. The callback function also receives these exports:
@@ -139,9 +118,9 @@ All the options are supported. The callback function also receives these exports
     }
   }
 </script>
+
 <script
-  src="https://unpkg.com/@segment/consent-manager@3.0.0/standalone/consent-manager.js"
-  crossorigin="anonymous"
+  src="https://unpkg.com/@segment/consent-manager@4.0.0/standalone/consent-manager.js"
   defer
 ></script>
 ```

--- a/src/standalone.tsx
+++ b/src/standalone.tsx
@@ -8,7 +8,6 @@ import { CloseBehavior } from './consent-manager/container'
 export const version = process.env.VERSION
 export { openConsentManager, doNotTrack, inEU }
 
-const dataset = document.currentScript && document.currentScript.dataset
 // TODO: define string based input type that can be parsed to `ConsentManagerInput`
 let props: Partial<ConsentManagerInput> = {}
 let containerRef: string | undefined
@@ -26,26 +25,10 @@ if (localWindow.consentManagerConfig) {
       inEU
     })
   } else {
-    props = localWindow.consentManagerConfig
+    throw new Error(`window.consentManagerConfig should be a function`)
   }
+
   containerRef = props.container
-} else if (dataset) {
-  // Allow using data attributes on the script tag
-  containerRef = dataset.container
-  props.writeKey = dataset.writekey
-  // @ts-ignore
-  props.otherWriteKeys = dataset.otherwritekeys
-  props.implyConsentOnInteraction = dataset.implyconsentoninteraction as boolean | undefined
-  props.cookieDomain = dataset.cookiedomain
-  props.bannerContent = dataset.bannercontent
-  props.bannerTextColor = dataset.bannertextcolor
-  props.bannerBackgroundColor = dataset.bannerbackgroundcolor
-  props.preferencesDialogTitle = dataset.preferencesdialogtitle
-  props.preferencesDialogContent = dataset.preferencesdialogcontent
-  props.cancelDialogTitle = dataset.canceldialogtitle
-  props.cancelDialogContent = dataset.canceldialogcontent
-  // @ts-ignore
-  props.closeBehavior = dataset.closebehavior
 }
 
 if (!containerRef) {
@@ -68,10 +51,6 @@ if (!props.cancelDialogContent) {
   throw new Error('ConsentManager: cancelDialogContent is required')
 }
 
-if (typeof props.otherWriteKeys === 'string') {
-  props.otherWriteKeys = (props.otherWriteKeys as string).split(',')
-}
-
 if (typeof props.implyConsentOnInteraction === 'string') {
   props.implyConsentOnInteraction = props.implyConsentOnInteraction === 'true'
 }
@@ -82,6 +61,7 @@ if (props.closeBehavior !== undefined && typeof props.closeBehavior === 'string'
     CloseBehavior.DENY.toString(),
     CloseBehavior.DISMISS.toString()
   ]
+
   if (!options.includes(props.closeBehavior)) {
     throw new Error(`ConsentManager: closeBehavior should be one of ${options}`)
   }

--- a/src/standalone.tsx
+++ b/src/standalone.tsx
@@ -8,27 +8,22 @@ import { CloseBehavior } from './consent-manager/container'
 export const version = process.env.VERSION
 export { openConsentManager, doNotTrack, inEU }
 
-// TODO: define string based input type that can be parsed to `ConsentManagerInput`
 let props: Partial<ConsentManagerInput> = {}
 let containerRef: string | undefined
 
 const localWindow = window as WindowWithConsentManagerConfig
 
-if (localWindow.consentManagerConfig) {
-  // Allow using global variable
-  if (typeof localWindow.consentManagerConfig === 'function') {
-    props = localWindow.consentManagerConfig({
-      React,
-      version,
-      openConsentManager,
-      doNotTrack,
-      inEU
-    })
-  } else {
-    throw new Error(`window.consentManagerConfig should be a function`)
-  }
-
+if (localWindow.consentManagerConfig && typeof localWindow.consentManagerConfig === 'function') {
+  props = localWindow.consentManagerConfig({
+    React,
+    version,
+    openConsentManager,
+    doNotTrack,
+    inEU
+  })
   containerRef = props.container
+} else {
+  throw new Error(`window.consentManagerConfig should be a function`)
 }
 
 if (!containerRef) {

--- a/stories/standalone.html
+++ b/stories/standalone.html
@@ -10,22 +10,27 @@
       Data Collection and Cookie Preferences
     </button>
 
+    <script type="application/javascript">
+      window.consentManagerConfig = function(exports) {
+        return {
+          container: '#consent-manager',
+          writeKey: 'tYQQPcY78Hc3T1hXUYk0n4xcbEHnN7r0',
+          bannerContent:
+            'We use cookies (and other similar technologies) to collect data to improve your experience on our site.',
+          bannerSubContent: 'You can change your preferences at any time.',
+          preferencesDialogTitle: 'Website Data Collection Preferences',
+          preferencesDialogContent:
+            'We use data collected by cookies and JavaScript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site.',
+          cancelDialogTitle: 'Are you sure you want to cancel?',
+          cancelDialogContent:
+            "Your preferences have not been saved. By continuing to use our website, you're agreeing to our Website Data Collection Policy",
+          closeBehavior: 'accept'
+        }
+      }
+    </script>
+
     <!-- Setup the Segment Consent Manager tag -->
-    <script
-      src="./standalone/consent-manager.js"
-      crossorigin="anonymous"
-      defer
-      data-container="#consent-manager"
-      data-writeKey="tYQQPcY78Hc3T1hXUYk0n4xcbEHnN7r0"
-      data-otherWriteKeys="vMRS7xbsjH97Bb2PeKbEKvYDvgMm5T3l"
-      data-bannerContent="We use cookies (and other similar technologies) to collect data to improve your experience on our site."
-      data-bannerSubContent="You can change your preferences at any time."
-      data-preferencesDialogTitle="Website Data Collection Preferences"
-      data-preferencesDialogContent="We use data collected by cookies and JavaScript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site."
-      data-cancelDialogTitle="Are you sure you want to cancel?"
-      data-cancelDialogContent="Your preferences have not been saved. By continuing to use our website, you're agreeing to our Website Data Collection Policy"
-      data-closeBehavior="accept"
-    ></script>
+    <script src="./standalone/consent-manager.js" defer></script>
 
     <!-- Load analytics.js -->
     <script>


### PR DESCRIPTION
Remove support to `dataset` attributes for the consent manager tag as it could potentially encourage customers to use features that don't have full compatibility with analytics.js