### PR TITLE
Expose preferences manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ The following global variables are also exposed:
 - `consentManager.openConsentManager()` - Opens the consent manager preferences dialog.
 - `consentManager.doNotTrack()` - Utility function that returns the user's Do Not Track preference (normalises the cross browser API differences). Returns `true`, `false` or `null` (no preference specified).
 - `consentManager.inEU()` - The [@segment/in-eu][ineu] `inEU()` function.
+- `consentManager.preferences` - Returns an instance of `PreferencesManager` with the following helper functions:
+  - `loadPreferences` - returns the cookie value for consent preferences
+  - `savePreferences` - allows for managing the consent cookie programatically (useful if you want to re-hydrate consent from your own database or prefill consent options)
+  - `onPreferencesSaved(callback)` - allows for subscribing to changes in preferences.
 
 #### Callback Function
 
@@ -78,6 +82,10 @@ All the options are supported. The callback function also receives these exports
 - `openConsentManager()` - Opens the consent manager preferences dialog.
 - `doNotTrack()` - Utility function that returns the user's Do Not Track preference (normalises the cross browser API differences). Returns `true`, `false` or `null` (no preference specified).
 - `inEU()` - The [@segment/in-eu][ineu] `inEU()` function.
+- `consentManager.preferences` - Returns an instance of `PreferencesManager` with the following helper functions:
+  - `loadPreferences` - returns the cookie value for consent preferences
+  - `savePreferences` - allows for managing the consent cookie programatically (useful if you want to re-hydrate consent from your own database or prefill consent options)
+  - `onPreferencesSaved(callback)` - allows for subscribing to changes in preferences.
 
 ```html
 <script>

--- a/src/consent-manager-builder/preferences.ts
+++ b/src/consent-manager-builder/preferences.ts
@@ -8,6 +8,12 @@ const COOKIE_KEY = 'tracking-preferences'
 // TODO: Make cookie expiration configurable
 const COOKIE_EXPIRES = 365
 
+export interface PreferencesManager {
+  loadPreferences(): Preferences
+  onPreferencesSaved(listener: (prefs: Preferences) => void): void
+  savePreferences(prefs: SavePreferences): void
+}
+
 // TODO: harden against invalid cookies
 // TODO: harden against different versions of cookies
 export function loadPreferences(): Preferences {

--- a/src/standalone.tsx
+++ b/src/standalone.tsx
@@ -4,9 +4,10 @@ import inEU from '@segment/in-eu'
 import { ConsentManager, openConsentManager, doNotTrack } from '.'
 import { ConsentManagerProps, WindowWithConsentManagerConfig, ConsentManagerInput } from './types'
 import { CloseBehavior } from './consent-manager/container'
+import * as preferences from './consent-manager-builder/preferences'
 
 export const version = process.env.VERSION
-export { openConsentManager, doNotTrack, inEU }
+export { openConsentManager, doNotTrack, inEU, preferences }
 
 let props: Partial<ConsentManagerInput> = {}
 let containerRef: string | undefined
@@ -19,7 +20,8 @@ if (localWindow.consentManagerConfig && typeof localWindow.consentManagerConfig 
     version,
     openConsentManager,
     doNotTrack,
-    inEU
+    inEU,
+    preferences
   })
   containerRef = props.container
 } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { CloseBehavior } from './consent-manager/container'
+import { PreferencesManager } from './consent-manager-builder/preferences'
 
 type AJS = SegmentAnalytics.AnalyticsJS & {
   initialized: boolean
@@ -26,6 +27,7 @@ interface StandaloneConsentManagerParams {
   openConsentManager: () => void
   doNotTrack: () => boolean | null
   inEU: () => boolean
+  preferences: PreferencesManager
 }
 
 export interface Preferences {

--- a/stories/standalone-custom.html
+++ b/stories/standalone-custom.html
@@ -2,6 +2,11 @@
   <body>
     <script type="application/javascript">
       window.consentManagerConfig = function(exports) {
+        exports.preferences.onPreferencesSaved(function(prefs) {
+          console.log('preferences changed!', prefs)
+          // could be used to store consent server side, or send it into an API
+        })
+
         return {
           container: '#consent-manager',
           writeKey: 'tYQQPcY78Hc3T1hXUYk0n4xcbEHnN7r0',


### PR DESCRIPTION
Export `PreferencesManager` as part of the standalone build, so that developers can manage cookie preferences programmatically outside of the consent manager UI.