### PR TITLE
Release 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.1.0(Dec 11, 2019)
+
+### Added
+
+- [#60](https://github.com/segmentio/consent-manager/pull/60) Add new `customCategories` option
+
 ## 4.0.1(Oct 10, 2019)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Options:
 
 ##### implyConsentOnInteraction
 
-**_ Breaking Change _** (versions < 3.0.0 will default this option `true`)
+**_Breaking Change_** (versions < 3.0.0 will default this option `true`)
 
 Type: `boolean`<br>
 Default: `false` (as of 3.0.0)
@@ -239,6 +239,24 @@ The title of the cancel dialog.
 Type: `PropTypes.node`
 
 The content of the cancel dialog.
+
+##### customCategories
+
+Type: `PropTypes.object`<br>
+Default: `undefined`
+
+An object representing custom consent categories - mapping custom categories to Segment integrations, i.e:
+
+```javascript
+const customCategories = {
+  'New Category': {
+    purpose: 'A new consent category to capture more granular consent groupings',
+    integrations: ['Google Adwords (Classic)', 'Amplitude', 'Slack']
+  }
+}
+```
+
+The values for `integrations` should be an integration's name (`integration.name`). You can find examples of that by going to `https://cdn.segment.com/v1/projects/<writeKey>/integrations`
 
 #### Example
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/consent-manager",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Drop-in consent management plugin for analytics.js",
   "keywords": [
     "gdpr",


### PR DESCRIPTION
This PR:
- bumps version from 4.0.1 to 4.1.0
- Adds to changelog documenting the changes from PR #60 
- Adds documentation of `customCategories` to the README

<img width="903" alt="Screen Shot 2019-12-11 at 4 19 22 PM" src="https://user-images.githubusercontent.com/31225471/70671837-43d20000-1c32-11ea-9d09-f26d78c15be3.png">
