### PR TITLE
Custom onClose Behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ const customCategories = {
 }
 ```
 
-The values for `integrations` should be an integration's name (`integration.name`). You can find examples of that by going to `https://cdn.segment.com/v1/projects/<writeKey>/integrations`
+The values for `integrations` should be an integration's creationName (`integration.creationName`). You can find examples of that by going to `https://cdn.segment.com/v1/projects/<writeKey>/integrations`
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Callback function that determines if consent is required before tracking can beg
 
 ##### closeBehavior
 
-Type: `enum|string`<br>
+Type: `enum|string` or `function`<br>
 Default: `dismiss`
 
 An option to determine what should be the default behavior for the `x` button on the consent manager banner.
@@ -171,6 +171,17 @@ Options:
 - `dismiss` (default) - Dismisses the banner, but don't save or change any preferences. Analytics.js won't be loaded until explicit consent is given.
 - `accept` - Assume consent across every category.
 - `deny` - Denies consent across every category.
+
+`closeBehavior` can also be customized - i.e. don't load some categories, but load everything else. For example, if you wanted to load everything _except_ advertising, you could pass the following as `closeBehavior`:
+
+```
+closeBehavior={
+  (categories) => ({
+    ...categories,
+    advertising: false
+  })
+}
+```
 
 ##### implyConsentOnInteraction
 

--- a/src/consent-manager-builder/fetch-destinations.ts
+++ b/src/consent-manager-builder/fetch-destinations.ts
@@ -33,6 +33,5 @@ export default async function fetchDestinations(writeKeys: string[]): Promise<De
   destinations = destinations.filter(d => d.id !== 'Repeater')
   destinations = sortBy(destinations, ['id'])
   destinations = sortedUniqBy(destinations, 'id')
-
   return destinations
 }

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -109,6 +109,8 @@ const Container: React.FC<ContainerProps> = props => {
   })
 
   const onClose = () => {
+    console.log(props.preferences)
+
     if (props.closeBehavior === undefined || props.closeBehavior === CloseBehavior.DISMISS) {
       return toggleBanner(false)
     }
@@ -118,11 +120,12 @@ const Container: React.FC<ContainerProps> = props => {
     }
 
     if (props.closeBehavior === CloseBehavior.DENY) {
-      props.setPreferences({
-        advertising: false,
-        functional: false,
-        marketingAndAnalytics: false
-      })
+      const falsePreferences = Object.keys(props.preferences).reduce((acc, category) => {
+        acc[category] = false
+        return acc
+      }, {})
+
+      props.setPreferences(falsePreferences)
       return props.saveConsent()
     }
   }

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -18,7 +18,7 @@ export const enum CloseBehavior {
 }
 
 export interface CloseBehaviorFunction {
-  (preferences: CategoryPreferences): CategoryPreferences
+  (categories: CategoryPreferences): CategoryPreferences
 }
 
 interface ContainerProps {

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -113,7 +113,6 @@ const Container: React.FC<ContainerProps> = props => {
   })
 
   const onClose = () => {
-    console.log(props.preferences)
     if (props.closeBehavior === undefined || props.closeBehavior === CloseBehavior.DISMISS) {
       return toggleBanner(false)
     }
@@ -135,7 +134,8 @@ const Container: React.FC<ContainerProps> = props => {
     // closeBehavior is a custom function
     const customClosePreferences = props.closeBehavior(props.preferences)
     props.setPreferences(customClosePreferences)
-    return props.saveConsent()
+    props.saveConsent()
+    return toggleBanner(false)
   }
 
   const handleCategoryChange = (category: string, value: boolean) => {

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -17,11 +17,15 @@ export const enum CloseBehavior {
   DISMISS = 'dismiss'
 }
 
+export interface CloseBehaviorFunction {
+  (preferences: CategoryPreferences): CategoryPreferences
+}
+
 interface ContainerProps {
   setPreferences: (prefs: CategoryPreferences) => void
   saveConsent: (newPreferences?: CategoryPreferences, shouldReload?: boolean) => void
   resetPreferences: () => void
-  closeBehavior?: CloseBehavior
+  closeBehavior?: CloseBehavior | CloseBehaviorFunction
   destinations: Destination[]
   customCategories?: CustomCategories | undefined
   newDestinations: Destination[]
@@ -110,7 +114,6 @@ const Container: React.FC<ContainerProps> = props => {
 
   const onClose = () => {
     console.log(props.preferences)
-
     if (props.closeBehavior === undefined || props.closeBehavior === CloseBehavior.DISMISS) {
       return toggleBanner(false)
     }
@@ -128,6 +131,11 @@ const Container: React.FC<ContainerProps> = props => {
       props.setPreferences(falsePreferences)
       return props.saveConsent()
     }
+
+    // closeBehavior is a custom function
+    const customClosePreferences = props.closeBehavior(props.preferences)
+    props.setPreferences(customClosePreferences)
+    return props.saveConsent()
   }
 
   const handleCategoryChange = (category: string, value: boolean) => {

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -131,7 +131,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
         // Mark custom categories 
         Object.entries(customCategories).forEach(([categoryName, { integrations }]) => {
           const consentAlreadySetToFalse = destinationPreferences[destination.id] === false
-          const shouldSetConsent = integrations.includes(destination.name)
+          const shouldSetConsent = integrations.includes(destination.id)
           if (shouldSetConsent && !consentAlreadySetToFalse) {
             destinationPreferences[destination.id] = customPreferences[categoryName]
           }

--- a/src/consent-manager/preference-dialog.tsx
+++ b/src/consent-manager/preference-dialog.tsx
@@ -299,7 +299,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                       </td>
                       <td className={hideOnMobile}>
                         {destinations
-                          .filter(d => integrations.includes(d.name))
+                          .filter(d => integrations.includes(d.id))
                           .map(d => d.name)
                           .join(', ')}
                       </td>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { CloseBehavior } from './consent-manager/container'
+import { CloseBehavior, CloseBehaviorFunction } from './consent-manager/container'
 import { PreferencesManager } from './consent-manager-builder/preferences'
 
 type AJS = SegmentAnalytics.AnalyticsJS & {
@@ -75,7 +75,7 @@ export interface ConsentManagerProps {
   onError?: (error: Error | undefined) => void
   cancelDialogTitle?: React.ReactNode
   cancelDialogContent: React.ReactNode
-  closeBehavior?: CloseBehavior
+  closeBehavior?: CloseBehavior | CloseBehaviorFunction
   initialPreferences?: CategoryPreferences
   customCategories?: CustomCategories
 }

--- a/stories/0-consent-manager.stories.tsx
+++ b/stories/0-consent-manager.stories.tsx
@@ -3,7 +3,7 @@ import cookies from 'js-cookie'
 import { Pane, Heading, Button } from 'evergreen-ui'
 import { ConsentManager, openConsentManager, loadPreferences, onPreferencesSaved } from '../src'
 import { storiesOf } from '@storybook/react'
-import { CloseBehavior } from '../src/consent-manager/container'
+import { CloseBehavior, CloseBehaviorFunction } from '../src/consent-manager/container'
 import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs'
 import SyntaxHighlighter from 'react-syntax-highlighter'
 import { Preferences } from '../src/types'
@@ -64,7 +64,7 @@ const cancelDialogContent = (
   </div>
 )
 
-const ConsentManagerExample = (props: { closeBehavior: CloseBehavior }) => {
+const ConsentManagerExample = (props: { closeBehavior: CloseBehavior | CloseBehaviorFunction }) => {
   const [prefs, updatePrefs] = React.useState<Preferences>(loadPreferences())
 
   const cleanup = onPreferencesSaved(preferences => {
@@ -138,3 +138,12 @@ storiesOf('React Component / OnClose interactions', module)
   .add(`Dismiss`, () => <ConsentManagerExample closeBehavior={CloseBehavior.DISMISS} />)
   .add(`Accept`, () => <ConsentManagerExample closeBehavior={CloseBehavior.ACCEPT} />)
   .add(`Deny`, () => <ConsentManagerExample closeBehavior={CloseBehavior.DENY} />)
+  .add(`Custom Close Behavior`, () => (
+    <ConsentManagerExample
+      closeBehavior={_preferences => ({
+        advertising: false,
+        marketingAndAnalytics: true,
+        functional: true
+      })}
+    />
+  ))

--- a/stories/0-consent-manager.stories.tsx
+++ b/stories/0-consent-manager.stories.tsx
@@ -140,10 +140,9 @@ storiesOf('React Component / OnClose interactions', module)
   .add(`Deny`, () => <ConsentManagerExample closeBehavior={CloseBehavior.DENY} />)
   .add(`Custom Close Behavior`, () => (
     <ConsentManagerExample
-      closeBehavior={_preferences => ({
-        advertising: false,
-        marketingAndAnalytics: true,
-        functional: true
+      closeBehavior={categories => ({
+        ...categories,
+        advertising: false
       })}
     />
   ))

--- a/stories/5-custom-categories.stories.tsx
+++ b/stories/5-custom-categories.stories.tsx
@@ -146,7 +146,8 @@ storiesOf('Custom Categories - Do Not Sell', module)
   .add(`Deny`, () => <ConsentManagerExample closeBehavior={CloseBehavior.DENY} />)
   .add(`Custom Close Behavior`, () => (
     <ConsentManagerExample
-      closeBehavior={_preferences => ({
+      closeBehavior={categories => ({
+        ...categories,
         'Do Not Sell': false
       })}
     />

--- a/stories/5-custom-categories.stories.tsx
+++ b/stories/5-custom-categories.stories.tsx
@@ -91,7 +91,7 @@ const ConsentManagerExample = (props: { closeBehavior: CloseBehavior | CloseBeha
         closeBehavior={props.closeBehavior}
         customCategories={{
           'Do Not Sell': {
-            integrations: ['Google Ads (Classic)'],
+            integrations: ['AdWords'],
             purpose: 'To give the right to opt out of the sale of personal data.'
           }
         }}

--- a/stories/5-custom-categories.stories.tsx
+++ b/stories/5-custom-categories.stories.tsx
@@ -3,7 +3,7 @@ import cookies from 'js-cookie'
 import { Pane, Heading, Button } from 'evergreen-ui'
 import { ConsentManager, openConsentManager, loadPreferences, onPreferencesSaved } from '../src'
 import { storiesOf } from '@storybook/react'
-import { CloseBehavior } from '../src/consent-manager/container'
+import { CloseBehavior, CloseBehaviorFunction } from '../src/consent-manager/container'
 import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs'
 import SyntaxHighlighter from 'react-syntax-highlighter'
 import { Preferences } from '../src/types'
@@ -64,7 +64,7 @@ const cancelDialogContent = (
   </div>
 )
 
-const ConsentManagerExample = (props: { closeBehavior: CloseBehavior }) => {
+const ConsentManagerExample = (props: { closeBehavior: CloseBehavior | CloseBehaviorFunction }) => {
   const [prefs, updatePrefs] = React.useState<Preferences>(loadPreferences())
 
   const cleanup = onPreferencesSaved(preferences => {
@@ -140,6 +140,14 @@ const ConsentManagerExample = (props: { closeBehavior: CloseBehavior }) => {
   )
 }
 
-storiesOf('Custom Categories', module).add(`Do Not Sell`, () => (
-  <ConsentManagerExample closeBehavior={CloseBehavior.DISMISS} />
-))
+storiesOf('Custom Categories - Do Not Sell', module)
+  .add(`Dismiss`, () => <ConsentManagerExample closeBehavior={CloseBehavior.DISMISS} />)
+  .add(`Accept`, () => <ConsentManagerExample closeBehavior={CloseBehavior.ACCEPT} />)
+  .add(`Deny`, () => <ConsentManagerExample closeBehavior={CloseBehavior.DENY} />)
+  .add(`Custom Close Behavior`, () => (
+    <ConsentManagerExample
+      closeBehavior={_preferences => ({
+        'Do Not Sell': false
+      })}
+    />
+  ))


### PR DESCRIPTION
# Add Custom `closeBehavior`
This PR allows `closeBehavior` to be a function, in order to support more custom on-close behaviors. 

For example, CCPA stipulates that we only need to stop tracking for advertising when a user closes the banner - all other tracking can remain. We can accomplish that with this PR by doing the following:

```
customCategories={
    (categories) => ({
        ...categories,
        advertising: false
      })
}
```

This PR also addresses a previous PR comment about changing `destination.name --> destination.id`: https://github.com/segmentio/consent-manager/commit/8e21a8ba08ca79c17f6638054feaf2efdabc7ae6#r36424324

## README Update
The README has been updated to include documentation about this new feature:
<img width="924" alt="Screen Shot 2019-12-19 at 4 05 35 PM" src="https://user-images.githubusercontent.com/31225471/71219290-722a8d80-2279-11ea-86a9-4d12986168ea.png">

## New Stories
This PR also adds 5 new stories: 
- Regular ConsentManager w/ custom closeBehavior
- Consent Manager w/ customCategories and
    - Dismiss closeBehavior
    - Accept closeBehavior
    - Deny closeBehavior
    - custom closeBehavior

<img width="211" alt="Screen Shot 2019-12-19 at 4 07 53 PM" src="https://user-images.githubusercontent.com/31225471/71219376-bd44a080-2279-11ea-8181-016c3246730a.png">

Each of these can be tested for expected behavior by:
1. Clearing the existing cookie
2. Clicking 'x' on the banner above
3. Ensure that the corresponding cookie that is set (or not set) matches the expected close behavior.

## Extending for Segment (internal) CCPA + GDPR readiness 
Extending consent manager to cover some use cases might look like this now (using our internal in-regions package):
```
const shouldRequireConsent = inRegions(['EU', 'CA'])
  const inCA = inRegions(['CA'])
  const inEU = inRegions(['EU'])

  const closeBehavior = inCA()
    ? _categories => ({
        advertising: false,
        marketingAndAnalytics: true,
        functional: true
      })
    : inEU()
    ? CloseBehavior.DENY
    : CloseBehavior.ACCEPT
```