### PR TITLE
Fix Destination Preferences Bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@segment/consent-manager",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Drop-in consent management plugin for analytics.js",
   "keywords": [
     "gdpr",

--- a/src/consent-manager-builder/analytics.ts
+++ b/src/consent-manager-builder/analytics.ts
@@ -3,7 +3,7 @@ import { WindowWithAJS, Destination } from '../types'
 interface AnalyticsParams {
   writeKey: string
   destinations: Destination[]
-  destinationPreferences: object | null
+  destinationPreferences: object | null | undefined
   isConsentRequired: boolean
   shouldReload?: boolean
 }

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -143,14 +143,14 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       mapCustomPreferences
     } = this.props
     // TODO: add option to run mapCustomPreferences on load so that the destination preferences automatically get updated
-    let { destinationPreferences = {}, customPreferences } = loadPreferences()
+    let { destinationPreferences, customPreferences } = loadPreferences()
 
     const [isConsentRequired, destinations] = await Promise.all([
       shouldRequireConsent(),
       fetchDestinations([writeKey, ...otherWriteKeys])
     ])
 
-    const newDestinations = getNewDestinations(destinations, destinationPreferences)
+    const newDestinations = getNewDestinations(destinations, destinationPreferences || {})
 
     let preferences: CategoryPreferences | undefined
     if (mapCustomPreferences) {


### PR DESCRIPTION
Allow `destinationPreferences` to be undefined, so that the following code block can be executed/reached:

https://github.com/segmentio/consent-manager/blob/master/src/consent-manager-builder/analytics.ts#L22-L32