### PR TITLE
Add variable existence check for SSR apps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,23 +16,26 @@ type Nav = Navigator & {
 }
 
 export function doNotTrack(): boolean | null {
-  const nav = navigator as Nav
+  
+  if (typeof window !== 'undefined' && (window.navigator || navigator)) { 
+    const nav = navigator as Nav
 
-  let doNotTrackValue = nav.doNotTrack || window.doNotTrack || nav.msDoNotTrack
+    let doNotTrackValue = nav.doNotTrack || window.doNotTrack || nav.msDoNotTrack
 
-  // Normalise Firefox < 32
-  // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack
-  if (doNotTrackValue === 'yes') {
-    doNotTrackValue = '1'
-  } else if (doNotTrackValue === 'no') {
-    doNotTrackValue = '0'
-  }
+    // Normalise Firefox < 32
+    // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack
+    if (doNotTrackValue === 'yes') {
+      doNotTrackValue = '1'
+    } else if (doNotTrackValue === 'no') {
+      doNotTrackValue = '0'
+    }
 
-  if (doNotTrackValue === '1') {
-    return true
-  }
-  if (doNotTrackValue === '0') {
-    return false
+    if (doNotTrackValue === '1') {
+      return true
+    }
+    if (doNotTrackValue === '0') {
+      return false
+    }
   }
 
   return null


### PR DESCRIPTION
In order to use the consent-manager module with NextJS, Gatsby or any SSR framework, a variable existence check is needed to avoid errors in compilation time. This simple check won't modify the code behavior but will allow the projects to compile correctly.

In a project I'm developing in Gatsby, this is the error I get when I try to run the production build:

`failed Building static HTML for pages - 8.377s

 ERROR #95312

"navigator" is not available during server side rendering.

See our docs page for more info on this error: https://gatsby.dev/debug-html


   6 | export var ConsentManager = CM;
   7 | export function doNotTrack() {
>  8 | 	var nav = navigator;
     | ^
   9 | 	var doNotTrackValue = nav.doNotTrack || window.doNotTrack || nav.msDoNotTrack;
  10 | 	// Normalise Firefox < 32
  11 | 	// https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack


  WebpackError: ReferenceError: navigator is not defined

  - index.js:8 doNotTrack
    node_modules/@segment/consent-manager/esm/index.js:8:1`