### PR TITLE
Don't reload if no preferences have changed, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ All the options are supported. The callback function also receives these exports
 </script>
 
 <script
-  src="https://unpkg.com/@segment/consent-manager@4.0.0/standalone/consent-manager.js"
+  src="https://unpkg.com/@segment/consent-manager@4.3.0/standalone/consent-manager.js"
   defer
 ></script>
 ```

--- a/README.md
+++ b/README.md
@@ -402,6 +402,15 @@ Default: `{}`
 
 The current preferences in state. By default if should be in the format of `{destinationId: true|false}`, but if you're using [mapCustomPreferences][] the object map can be in any format you want. _Note: this isn't the saved preferences._
 
+##### havePreferencesChanged
+
+Type: `boolean`<br>
+Default: `false`
+
+A boolean value representing whether or not the user has changed their preferences since opening the preferences modal. Will be set to `true` if the user interacts with the preferences modal by selecting "Yes" or "No" on any of the consent categories.
+
+This is used to not reload the page if no preferences have changed, as to not create a disruptive user experience.
+
 ##### isConsentRequired
 
 Type: `boolean`<br>

--- a/README.md
+++ b/README.md
@@ -500,6 +500,15 @@ $ yarn dev
 
 and the storybook should be opened in your browser. We recommend adding a new story for new features, and testing against existing stories when making bug fixes.
 
+### Publishing New Version
+
+This package follows semantic versioning. To publish a new version:
+
+```
+$ npm version <new-version>
+$ npm publish
+```
+
 ## License
 
 consent-manager is released under the MIT license.

--- a/README.md
+++ b/README.md
@@ -490,6 +490,16 @@ export default function() {
 - `openConsentManager()` - Opens the [ConsentManager][] preferences dialog.
 - `doNotTrack()` - Returns the user's Do Not Track preference (normalises the cross browser API differences). Returns `true`, `false` or `null` (no preference specified).
 
+## Development
+
+To run our storybook locally, simply do:
+
+```
+$ yarn dev
+```
+
+and the storybook should be opened in your browser. We recommend adding a new story for new features, and testing against existing stories when making bug fixes.
+
 ## License
 
 consent-manager is released under the MIT license.

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -70,6 +70,7 @@ interface RenderProps {
   preferences: CategoryPreferences
   isConsentRequired: boolean
   customCategories?: CustomCategories
+  havePreferencesChanged: boolean
   setPreferences: (newPreferences: CategoryPreferences) => void
   resetPreferences: () => void
   saveConsent: (newPreferences?: CategoryPreferences | boolean, shouldReload?: boolean) => void
@@ -98,13 +99,20 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
     destinations: [],
     newDestinations: [],
     preferences: {},
-    isConsentRequired: true
+    isConsentRequired: true,
+    havePreferencesChanged: false
   }
 
   render() {
     const { children, customCategories } = this.props
-    const { isLoading, destinations, preferences, newDestinations, isConsentRequired } = this.state
-
+    const {
+      isLoading,
+      destinations,
+      preferences,
+      newDestinations,
+      isConsentRequired,
+      havePreferencesChanged
+    } = this.state
     if (isLoading) {
       return null
     }
@@ -115,6 +123,7 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       newDestinations,
       preferences,
       isConsentRequired,
+      havePreferencesChanged,
       setPreferences: this.handleSetPreferences,
       resetPreferences: this.handleResetPreferences,
       saveConsent: this.handleSaveConsent
@@ -194,7 +203,7 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
         newPreferences,
         existingPreferences
       })
-      return { ...prevState, preferences }
+      return { ...prevState, preferences, havePreferencesChanged: true }
     })
   }
 

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -30,6 +30,7 @@ interface ContainerProps {
   customCategories?: CustomCategories | undefined
   newDestinations: Destination[]
   preferences: CategoryPreferences
+  havePreferencesChanged: boolean
   isConsentRequired: boolean
   implyConsentOnInteraction: boolean
   bannerContent: React.ReactNode
@@ -146,6 +147,10 @@ const Container: React.FC<ContainerProps> = props => {
 
   const handleSave = () => {
     toggleDialog(false)
+    // If preferences haven't changed, don't reload the page as it's a disruptive experience for end-users
+    if (!props.havePreferencesChanged) {
+      return
+    }
     props.saveConsent()
   }
 

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -65,7 +65,8 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
           isConsentRequired,
           setPreferences,
           resetPreferences,
-          saveConsent
+          saveConsent,
+          havePreferencesChanged
         }) => {
           return <Container
             customCategories={customCategories}
@@ -88,6 +89,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
             preferencesDialogContent={preferencesDialogContent}
             cancelDialogTitle={cancelDialogTitle}
             cancelDialogContent={cancelDialogContent}
+            havePreferencesChanged={havePreferencesChanged}
           />
         }}
       </ConsentManagerBuilder>

--- a/stories/6-ccpa-gdpr-example.stories.tsx
+++ b/stories/6-ccpa-gdpr-example.stories.tsx
@@ -1,0 +1,170 @@
+import React from 'react'
+import cookies from 'js-cookie'
+import { Pane, Heading, Paragraph, Button } from 'evergreen-ui'
+import { ConsentManager, openConsentManager, loadPreferences, onPreferencesSaved } from '../src'
+import { storiesOf } from '@storybook/react'
+import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs'
+import SyntaxHighlighter from 'react-syntax-highlighter'
+import { Preferences } from '../src/types'
+import CookieView from './components/CookieView'
+import inRegions from '@segment/in-regions'
+import { CloseBehavior } from '../src/consent-manager/container'
+
+const bannerContent = (
+  <span>
+    We use cookies (and other similar technologies) to collect data to improve your experience on
+    our site. By using our website, you’re agreeing to the collection of data as described in our{' '}
+    <a
+      href="https://segment.com/docs/legal/website-data-collection-policy/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Website Data Collection Policy
+    </a>
+    .
+  </span>
+)
+const bannerSubContent = 'You can manage your preferences here!'
+const preferencesDialogTitle = 'Website Data Collection Preferences'
+const preferencesDialogContent = (
+  <div>
+    <p>
+      Segment uses data collected by cookies and JavaScript libraries to improve your browsing
+      experience, analyze site traffic, deliver personalized advertisements, and increase the
+      overall performance of our site.
+    </p>
+    <p>
+      By using our website, you’re agreeing to our{' '}
+      <a
+        href="https://segment.com/docs/legal/website-data-collection-policy/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Website Data Collection Policy
+      </a>
+      .
+    </p>
+    <p>
+      The table below outlines how we use this data by category. To opt out of a category of data
+      collection, select “No” and save your preferences.
+    </p>
+  </div>
+)
+const cancelDialogTitle = 'Are you sure you want to cancel?'
+const cancelDialogContent = (
+  <div>
+    Your preferences have not been saved. By continuing to use our website, you’re agreeing to our{' '}
+    <a
+      href="https://segment.com/docs/legal/website-data-collection-policy/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Website Data Collection Policy
+    </a>
+    .
+  </div>
+)
+
+const ConsentManagerExample = () => {
+  const [prefs, updatePrefs] = React.useState<Preferences>(loadPreferences())
+
+  const cleanup = onPreferencesSaved(preferences => {
+    updatePrefs(preferences)
+  })
+
+  React.useEffect(() => {
+    return () => {
+      cleanup()
+    }
+  })
+
+  const inCA = inRegions(['CA'])
+  const inEU = inRegions(['EU'])
+  const shouldRequireConsent = inRegions(['CA', 'EU'])
+  const caDefaultPreferences = {
+    advertising: false,
+    marketingAndAnalytics: true,
+    functional: true
+  }
+  const euDefaultPreferences = {
+    advertising: false,
+    marketingAndAnalytics: false,
+    functional: false
+  }
+
+  const closeBehavior = inCA()
+    ? _categories => caDefaultPreferences
+    : inEU()
+      ? CloseBehavior.DENY
+      : CloseBehavior.ACCEPT
+
+  const initialPreferences = inCA()
+    ? caDefaultPreferences
+    : inEU()
+      ? euDefaultPreferences
+      : undefined
+
+  return (
+    <Pane>
+      <ConsentManager
+        writeKey="tYQQPcY78Hc3T1hXUYk0n4xcbEHnN7r0"
+        otherWriteKeys={['vMRS7xbsjH97Bb2PeKbEKvYDvgMm5T3l']}
+        bannerContent={bannerContent}
+        bannerSubContent={bannerSubContent}
+        preferencesDialogTitle={preferencesDialogTitle}
+        preferencesDialogContent={preferencesDialogContent}
+        cancelDialogTitle={cancelDialogTitle}
+        cancelDialogContent={cancelDialogContent}
+        closeBehavior={closeBehavior}
+        shouldRequireConsent={shouldRequireConsent}
+        initialPreferences={initialPreferences}
+      />
+
+      <Pane marginX={100} marginTop={20}>
+        <Heading> Cute Cats </Heading>
+        <Pane display="flex">
+          <iframe
+            src="https://giphy.com/embed/JIX9t2j0ZTN9S"
+            width="480"
+            height="480"
+            frameBorder="0"
+          />
+
+          <iframe
+            src="https://giphy.com/embed/yFQ0ywscgobJK"
+            width="398"
+            height="480"
+            frameBorder="0"
+          />
+        </Pane>
+
+        <Paragraph marginTop={20}>
+          This example highlights checking for EU or CA residency, then changing the closeBehavior
+          based on membership in each.
+        </Paragraph>
+        <p>
+          <div>
+            <Heading>Current Preferences</Heading>
+            <SyntaxHighlighter language="json" style={docco}>
+              {JSON.stringify(prefs, null, 2)}
+            </SyntaxHighlighter>
+          </div>
+          <Button marginRight={20} onClick={openConsentManager}>
+            Change Cookie Preferences
+          </Button>
+          <Button
+            onClick={() => {
+              cookies.remove('tracking-preferences')
+              window.location.reload()
+            }}
+          >
+            Clear
+          </Button>
+        </p>
+      </Pane>
+      <CookieView />
+    </Pane>
+  )
+}
+
+storiesOf('CCPA + GDPR Example', module).add(`Basic`, () => <ConsentManagerExample />)


### PR DESCRIPTION
This PR:
- Addresses an issue open: https://github.com/segmentio/consent-manager/issues/78
- Makes it so that if the user saves the preferences modal, and no preferences have changed, the page is not reloaded - we heard that this is an abrupt user experience.

As a result, am introducing a `havePreferencesChanged` boolean that reflects whether or not preferences have been changed since opening the modal:
<img width="935" alt="Screen Shot 2020-03-24 at 11 45 03 PM" src="https://user-images.githubusercontent.com/31225471/77580605-880fa600-6e99-11ea-86c5-ea8b9abbaf57.png">

### Testing
The following tests should be applicable to these changes:
- On opening the preferences modal, if no changes have been made to the preferences, hitting 'Save' should _not_ reload the page
- On opening the preferences modal, if changes have been made, hitting 'Save' _should_ reload the page.

See this gif for examples of both cases:
![consentmanager](https://user-images.githubusercontent.com/31225471/77580707-b1303680-6e99-11ea-860c-c5c9a25f35e7.gif)
