### PR TITLE
Add defaultDestinationBehavior for when new destinations are added 

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,21 @@ Default: `false` (as of 3.0.0)
 
 Whether or not consent should be implied if the user interacts with the website (clicks anywhere outside the consent manager banner or dialogs).
 
+##### defaultDestinationBehavior
+
+Type: `string`<br>
+Default: 'disable'
+
+Determines how newly detected destinations are treated when the user already has a cookie set on their browser. This will be relevent when you've added a connected a new destination to any of the sources managed by Consent Manager.
+
+Options:
+
+- `disable` (default) - Newly detected destinations are by default, disabled.
+- `enable` - Newly detected destinations are by default, enabled.
+- `imply` - Newly detected destinations are by default, enabled or disabled, depending on the user's consent to the consent group that the new destination belongs to.
+  - For example, if a user has already consented to the "marketingAndAnalytics" category, and we detect a new destination with category "Analytics", that destination will be enabled.
+- `ask` - If we detect new destinations upon initializing the Consent Manager, the preferences dialog will automatically open, asking the user for their consent again.
+
 ##### cookieDomain
 
 Type: `string`<br>
@@ -355,6 +370,20 @@ Default: `{}`
 
 The initial value of the preferences. By default it should be an object map of `{destinationId: true|false}`. If you're using [mapCustomPreferences][] it should be an object map of your custom preferences' default values.
 
+##### defaultDestinationBehavior
+
+Type: `string`<br>
+Default: 'disable'
+
+Determines how newly detected destinations are treated when the user already has a cookie set on their browser. This will be relevent when you've added a connected a new destination to any of the sources managed by Consent Manager.
+
+Options:
+
+- `disable` (default) - Newly detected destinations are by default, disabled.
+- `enable` - Newly detected destinations are by default, enabled.
+- `imply` - Newly detected destinations are by default, enabled or disabled, depending on the user's consent to the consent group that the new destination belongs to.
+  - For example, if a user has already consented to the "marketingAndAnalytics" category, and we detect a new destination with category "Analytics", that destination will be enabled.
+
 ##### mapCustomPreferences
 
 Type: `function`<br>
@@ -417,6 +446,13 @@ Type: `boolean`<br>
 Default: `true`
 
 The result of [shouldRequireConsent][].
+
+##### workspaceAddedNewDestinations
+
+Type: `boolean`<br>
+Default: `false`
+
+A boolean value representing whether or not there have been new destinations connected to the source(s) managed by Consent Manager, compared to the destinations set on the existing cookie.
 
 ##### setPreferences
 

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     },
     {
       "path": "standalone/consent-manager.js",
-      "limit": "45 KB"
+      "limit": "46 KB"
     }
   ],
   "husky": {

--- a/src/__tests__/consent-manager-builder/analytics.test.ts
+++ b/src/__tests__/consent-manager-builder/analytics.test.ts
@@ -179,4 +179,66 @@ describe('analytics', () => {
       }
     })
   })
+
+  test('sets new destinations to false if defaultDestinationBehavior is set to "disable"', () => {
+    const ajsLoad = sinon.spy()
+    wd.analytics = { load: ajsLoad }
+    const writeKey = '123'
+    const destinations = [
+      { id: 'Amplitude' } as Destination,
+      { id: 'Google Analytics' } as Destination
+    ]
+    const destinationPreferences = {
+      Amplitude: true
+    }
+
+    conditionallyLoadAnalytics({
+      writeKey,
+      destinations,
+      destinationPreferences,
+      isConsentRequired: false,
+      shouldReload: true,
+      defaultDestinationBehavior: 'disable'
+    })
+
+    expect(ajsLoad.args[0][1]).toMatchObject({
+      integrations: {
+        All: false,
+        Amplitude: true,
+        'Google Analytics': false,
+        'Segment.io': true
+      }
+    })
+  })
+
+  test('sets new destinations to true if defaultDestinationBehavior is set to "enable"', () => {
+    const ajsLoad = sinon.spy()
+    wd.analytics = { load: ajsLoad }
+    const writeKey = '123'
+    const destinations = [
+      { id: 'Amplitude' } as Destination,
+      { id: 'Google Analytics' } as Destination
+    ]
+    const destinationPreferences = {
+      Amplitude: true
+    }
+
+    conditionallyLoadAnalytics({
+      writeKey,
+      destinations,
+      destinationPreferences,
+      isConsentRequired: false,
+      shouldReload: true,
+      defaultDestinationBehavior: 'enable'
+    })
+
+    expect(ajsLoad.args[0][1]).toMatchObject({
+      integrations: {
+        All: false,
+        Amplitude: true,
+        'Google Analytics': true,
+        'Segment.io': true
+      }
+    })
+  })
 })

--- a/src/__tests__/consent-manager-builder/index.todo.js
+++ b/src/__tests__/consent-manager-builder/index.todo.js
@@ -3,6 +3,7 @@ import { shallow } from 'enzyme'
 import nock from 'nock'
 import sinon from 'sinon'
 import ConsentManagerBuilder from '../../consent-manager-builder'
+import { ADVERTISING_CATEGORIES, FUNCTIONAL_CATEGORIES } from '../../consent-manager/categories'
 
 describe('ConsentManagerBuilder', () => {
   beforeEach(() => {
@@ -171,9 +172,10 @@ describe('ConsentManagerBuilder', () => {
 
   test('if defaultDestinationBehavior is set to imply and category is set to true, loads new destination', done => {
     document.cookie =
-      'tracking-preferences={%22destinations%22:{%22Amplitude%22:true%2C}%2C%22custom%22:{%22advertising%22:false%2C%22marketingAndAnalytics%22:true%2C%22functional%22:true}}'
-    window.analytics = { load() {} }
+      'tracking-preferences={%22version%22:1%2C%22destinations%22:{%22Amplitude%22:true}%2C%22custom%22:{%22advertising%22:false%2C%22marketingAndAnalytics%22:true%2C%22functional%22:true}}'
+    window.analytics = { load() {}, identify() {} }
 
+    console.log('document.cookie ', document.cookie)
     nock('https://cdn.segment.com')
       .get('/v1/projects/123/integrations')
       .reply(200, [
@@ -188,10 +190,52 @@ describe('ConsentManagerBuilder', () => {
       ])
 
     shallow(
-      <ConsentManagerBuilder defaultDestinationBehavior="imply" writeKey="123">
-        {props => {
-          console.log(props)
-          expect(props.preferences).toMatchObject({
+      <ConsentManagerBuilder
+        defaultDestinationBehavior="imply"
+        writeKey="123"
+        mapCustomPreferences={(destinations, preferences) => {
+          const destinationPreferences = {}
+          const customPreferences = {}
+          // Default unset preferences to true (for implicit consent)
+          for (const preferenceName of Object.keys(preferences)) {
+            const value = preferences[preferenceName]
+            if (typeof value === 'boolean') {
+              customPreferences[preferenceName] = value
+            } else {
+              customPreferences[preferenceName] = true
+            }
+          }
+
+          const customPrefs = customPreferences
+
+          for (const destination of destinations) {
+            // Mark advertising destinations
+            if (
+              ADVERTISING_CATEGORIES.find(c => c === destination.category) &&
+              destinationPreferences[destination.id] !== false
+            ) {
+              destinationPreferences[destination.id] = customPrefs.advertising
+            }
+
+            // Mark function destinations
+            if (
+              FUNCTIONAL_CATEGORIES.find(c => c === destination.category) &&
+              destinationPreferences[destination.id] !== false
+            ) {
+              destinationPreferences[destination.id] = customPrefs.functional
+            }
+
+            // Fallback to marketing
+            if (!(destination.id in destinationPreferences)) {
+              destinationPreferences[destination.id] = customPrefs.marketingAndAnalytics
+            }
+          }
+
+          return { destinationPreferences, customPreferences }
+        }}
+      >
+        {({ preferences }) => {
+          expect(preferences).toMatchObject({
             Amplitude: true,
             'Google Analytics': true
           })
@@ -203,8 +247,8 @@ describe('ConsentManagerBuilder', () => {
 
   test('if defaultDestinationBehavior is set to imply and category is set to false, does not load new destination', done => {
     document.cookie =
-      'tracking-preferences={%22destinations%22:{%22Amplitude%22:false%2C}%2C%22custom%22:{%22advertising%22:false%2C%22marketingAndAnalytics%22:false%2C%22functional%22:true}}'
-    window.analytics = { load() {} }
+      'tracking-preferences={%22version%22:1%2C%22destinations%22:{%22Amplitude%22:true}%2C%22custom%22:{%22advertising%22:false%2C%22marketingAndAnalytics%22:false%2C%22functional%22:true}}'
+    window.analytics = { load() {}, identify() {} }
 
     nock('https://cdn.segment.com')
       .get('/v1/projects/123/integrations')
@@ -220,7 +264,51 @@ describe('ConsentManagerBuilder', () => {
       ])
 
     shallow(
-      <ConsentManagerBuilder defaultDestinationBehavior="imply" writeKey="123">
+      <ConsentManagerBuilder
+        defaultDestinationBehavior="imply"
+        writeKey="123"
+        mapCustomPreferences={(destinations, preferences) => {
+          const destinationPreferences = {}
+          const customPreferences = {}
+
+          // Default unset preferences to true (for implicit consent)
+          for (const preferenceName of Object.keys(preferences)) {
+            const value = preferences[preferenceName]
+            if (typeof value === 'boolean') {
+              customPreferences[preferenceName] = value
+            } else {
+              customPreferences[preferenceName] = true
+            }
+          }
+
+          const customPrefs = customPreferences
+
+          for (const destination of destinations) {
+            // Mark advertising destinations
+            if (
+              ADVERTISING_CATEGORIES.find(c => c === destination.category) &&
+              destinationPreferences[destination.id] !== false
+            ) {
+              destinationPreferences[destination.id] = customPrefs.advertising
+            }
+
+            // Mark function destinations
+            if (
+              FUNCTIONAL_CATEGORIES.find(c => c === destination.category) &&
+              destinationPreferences[destination.id] !== false
+            ) {
+              destinationPreferences[destination.id] = customPrefs.functional
+            }
+
+            // Fallback to marketing
+            if (!(destination.id in destinationPreferences)) {
+              destinationPreferences[destination.id] = customPrefs.marketingAndAnalytics
+            }
+          }
+
+          return { destinationPreferences, customPreferences }
+        }}
+      >
         {({ preferences }) => {
           expect(preferences).toMatchObject({
             Amplitude: false,

--- a/src/__tests__/consent-manager-builder/index.todo.js
+++ b/src/__tests__/consent-manager-builder/index.todo.js
@@ -169,6 +169,72 @@ describe('ConsentManagerBuilder', () => {
     )
   })
 
+  test('if defaultDestinationBehavior is set to imply and category is set to true, loads new destination', done => {
+    document.cookie =
+      'tracking-preferences={%22destinations%22:{%22Amplitude%22:false%2C}%2C%22custom%22:{%22advertising%22:false%2C%22marketingAndAnalytics%22:false%2C%22functional%22:true}}'
+    window.analytics = { load() {} }
+
+    nock('https://cdn.segment.com')
+      .get('/v1/projects/123/integrations')
+      .reply(200, [
+        {
+          name: 'Google Analytics',
+          creationName: 'Google Analytics'
+        },
+        {
+          name: 'Amplitude',
+          creationName: 'Amplitude'
+        }
+      ])
+
+    shallow(
+      <ConsentManagerBuilder defaultDestinationBehavior="imply" writeKey="123">
+        {({ preferences }) => {
+          expect(preferences).toMatchObject([
+            {
+              Amplitude: true,
+              'Google Analytics': true
+            }
+          ])
+          done()
+        }}
+      </ConsentManagerBuilder>
+    )
+  })
+
+  test('if defaultDestinationBehavior is set to imply and category is set to false, does not load new destination', done => {
+    document.cookie =
+      'tracking-preferences={%22destinations%22:{%22Amplitude%22:false%2C}%2C%22custom%22:{%22advertising%22:false%2C%22marketingAndAnalytics%22:false%2C%22functional%22:true}}'
+    window.analytics = { load() {} }
+
+    nock('https://cdn.segment.com')
+      .get('/v1/projects/123/integrations')
+      .reply(200, [
+        {
+          name: 'Google Analytics',
+          creationName: 'Google Analytics'
+        },
+        {
+          name: 'Amplitude',
+          creationName: 'Amplitude'
+        }
+      ])
+
+    shallow(
+      <ConsentManagerBuilder defaultDestinationBehavior="imply" writeKey="123">
+        {({ preferences }) => {
+          expect(preferences).toMatchObject([
+            {
+              Amplitude: false,
+              'Google Analytics': false
+            }
+          ])
+          done()
+        }}
+      </ConsentManagerBuilder>
+    )
+  })
+
   test.todo('loads analytics.js normally when consent isn՚t required')
   test.todo('still applies preferences when consent isn՚t required')
   test.todo('provides a setPreferences() function for setting the preferences')

--- a/src/__tests__/consent-manager-builder/index.todo.js
+++ b/src/__tests__/consent-manager-builder/index.todo.js
@@ -171,7 +171,7 @@ describe('ConsentManagerBuilder', () => {
 
   test('if defaultDestinationBehavior is set to imply and category is set to true, loads new destination', done => {
     document.cookie =
-      'tracking-preferences={%22destinations%22:{%22Amplitude%22:false%2C}%2C%22custom%22:{%22advertising%22:false%2C%22marketingAndAnalytics%22:false%2C%22functional%22:true}}'
+      'tracking-preferences={%22destinations%22:{%22Amplitude%22:true%2C}%2C%22custom%22:{%22advertising%22:false%2C%22marketingAndAnalytics%22:true%2C%22functional%22:true}}'
     window.analytics = { load() {} }
 
     nock('https://cdn.segment.com')
@@ -189,13 +189,12 @@ describe('ConsentManagerBuilder', () => {
 
     shallow(
       <ConsentManagerBuilder defaultDestinationBehavior="imply" writeKey="123">
-        {({ preferences }) => {
-          expect(preferences).toMatchObject([
-            {
-              Amplitude: true,
-              'Google Analytics': true
-            }
-          ])
+        {props => {
+          console.log(props)
+          expect(props.preferences).toMatchObject({
+            Amplitude: true,
+            'Google Analytics': true
+          })
           done()
         }}
       </ConsentManagerBuilder>
@@ -223,12 +222,10 @@ describe('ConsentManagerBuilder', () => {
     shallow(
       <ConsentManagerBuilder defaultDestinationBehavior="imply" writeKey="123">
         {({ preferences }) => {
-          expect(preferences).toMatchObject([
-            {
-              Amplitude: false,
-              'Google Analytics': false
-            }
-          ])
+          expect(preferences).toMatchObject({
+            Amplitude: false,
+            'Google Analytics': false
+          })
           done()
         }}
       </ConsentManagerBuilder>

--- a/src/__tests__/consent-manager-builder/index.todo.js
+++ b/src/__tests__/consent-manager-builder/index.todo.js
@@ -175,7 +175,6 @@ describe('ConsentManagerBuilder', () => {
       'tracking-preferences={%22version%22:1%2C%22destinations%22:{%22Amplitude%22:true}%2C%22custom%22:{%22advertising%22:false%2C%22marketingAndAnalytics%22:true%2C%22functional%22:true}}'
     window.analytics = { load() {}, identify() {} }
 
-    console.log('document.cookie ', document.cookie)
     nock('https://cdn.segment.com')
       .get('/v1/projects/123/integrations')
       .reply(200, [

--- a/src/consent-manager-builder/analytics.ts
+++ b/src/consent-manager-builder/analytics.ts
@@ -1,4 +1,4 @@
-import { WindowWithAJS, Destination } from '../types'
+import { WindowWithAJS, Destination, DefaultDestinationBehavior } from '../types'
 
 interface AnalyticsParams {
   writeKey: string
@@ -6,6 +6,7 @@ interface AnalyticsParams {
   destinationPreferences: object | null | undefined
   isConsentRequired: boolean
   shouldReload?: boolean
+  defaultDestinationBehavior?: DefaultDestinationBehavior
 }
 
 export default function conditionallyLoadAnalytics({
@@ -13,7 +14,8 @@ export default function conditionallyLoadAnalytics({
   destinations,
   destinationPreferences,
   isConsentRequired,
-  shouldReload = true
+  shouldReload = true,
+  defaultDestinationBehavior
 }: AnalyticsParams) {
   const wd = window as WindowWithAJS
   const integrations = { All: false, 'Segment.io': true }
@@ -32,6 +34,13 @@ export default function conditionallyLoadAnalytics({
   }
 
   for (const destination of destinations) {
+    // Was a preference explicitly set on this destination?
+    const explicitPreference = destination.id in destinationPreferences
+    if (!explicitPreference && defaultDestinationBehavior === 'enable') {
+      integrations[destination.id] = true
+      continue
+    }
+
     const isEnabled = Boolean(destinationPreferences[destination.id])
     if (isEnabled) {
       isAnythingEnabled = true

--- a/src/consent-manager-builder/analytics.ts
+++ b/src/consent-manager-builder/analytics.ts
@@ -57,6 +57,7 @@ export default function conditionallyLoadAnalytics({
     return
   }
 
+  //console.log('Loading integrations ', integrations)
   // Don't load a.js at all if nothing has been enabled
   if (isAnythingEnabled) {
     wd.analytics.load(writeKey, { integrations })

--- a/src/consent-manager-builder/analytics.ts
+++ b/src/consent-manager-builder/analytics.ts
@@ -57,7 +57,6 @@ export default function conditionallyLoadAnalytics({
     return
   }
 
-  //console.log('Loading integrations ', integrations)
   // Don't load a.js at all if nothing has been enabled
   if (isAnythingEnabled) {
     wd.analytics.load(writeKey, { integrations })

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -199,13 +199,10 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
         const mapped = mapCustomPreferences(destinations, preferences)
         destinationPreferences = mapped.destinationPreferences
         customPreferences = mapped.customPreferences
+        savePreferences({ destinationPreferences, customPreferences, cookieDomain })
       }
     } else {
       preferences = destinationPreferences || initialPreferences
-    }
-
-    if (workspaceAddedNewDestinations) {
-      savePreferences({ destinationPreferences, customPreferences, cookieDomain })
     }
 
     conditionallyLoadAnalytics({
@@ -284,8 +281,9 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       }
 
       const newDestinations = getNewDestinations(destinations, destinationPreferences)
+
       // If preferences haven't changed, don't reload the page as it's a disruptive experience for end-users
-      if (prevState.havePreferencesChanged || prevState.newDestinations.length > 0) {
+      if (prevState.havePreferencesChanged || newDestinations.length > 0) {
         savePreferences({ destinationPreferences, customPreferences, cookieDomain })
         conditionallyLoadAnalytics({
           writeKey,

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -81,6 +81,7 @@ interface RenderProps {
   isConsentRequired: boolean
   customCategories?: CustomCategories
   havePreferencesChanged: boolean
+  workspaceAddedNewDestinations: boolean
   setPreferences: (newPreferences: CategoryPreferences) => void
   resetPreferences: () => void
   saveConsent: (newPreferences?: CategoryPreferences | boolean, shouldReload?: boolean) => void
@@ -93,6 +94,7 @@ interface State {
   preferences?: CategoryPreferences
   isConsentRequired: boolean
   havePreferencesChanged: boolean
+  workspaceAddedNewDestinations: boolean
 }
 
 export default class ConsentManagerBuilder extends Component<Props, State> {
@@ -111,7 +113,8 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
     newDestinations: [],
     preferences: {},
     isConsentRequired: true,
-    havePreferencesChanged: false
+    havePreferencesChanged: false,
+    workspaceAddedNewDestinations: false
   }
 
   render() {
@@ -122,7 +125,8 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       preferences,
       newDestinations,
       isConsentRequired,
-      havePreferencesChanged
+      havePreferencesChanged,
+      workspaceAddedNewDestinations
     } = this.state
     if (isLoading) {
       return null
@@ -135,6 +139,7 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       preferences,
       isConsentRequired,
       havePreferencesChanged,
+      workspaceAddedNewDestinations,
       setPreferences: this.handleSetPreferences,
       resetPreferences: this.handleResetPreferences,
       saveConsent: this.handleSaveConsent
@@ -173,6 +178,10 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
     ])
 
     const newDestinations = getNewDestinations(destinations, destinationPreferences || {})
+    const workspaceAddedNewDestinations =
+      destinationPreferences &&
+      Object.keys(destinationPreferences).length > 0 &&
+      newDestinations.length > 0
 
     let preferences: CategoryPreferences | undefined
     if (mapCustomPreferences) {
@@ -185,7 +194,7 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
 
       if (
         (hasInitialPreferenceToTrue && emptyCustomPreferecences) ||
-        defaultDestinationBehavior === 'imply'
+        (defaultDestinationBehavior === 'imply' && workspaceAddedNewDestinations)
       ) {
         const mapped = mapCustomPreferences(destinations, preferences)
         destinationPreferences = mapped.destinationPreferences
@@ -195,7 +204,10 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       preferences = destinationPreferences || initialPreferences
     }
 
-    savePreferences({ destinationPreferences, customPreferences, cookieDomain })
+    if (workspaceAddedNewDestinations) {
+      savePreferences({ destinationPreferences, customPreferences, cookieDomain })
+    }
+
     conditionallyLoadAnalytics({
       writeKey,
       destinations,
@@ -209,7 +221,8 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       destinations,
       newDestinations,
       preferences,
-      isConsentRequired
+      isConsentRequired,
+      workspaceAddedNewDestinations: Boolean(workspaceAddedNewDestinations)
     })
   }
 

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -159,7 +159,8 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       otherWriteKeys = ConsentManagerBuilder.defaultProps.otherWriteKeys,
       shouldRequireConsent = ConsentManagerBuilder.defaultProps.shouldRequireConsent,
       initialPreferences,
-      mapCustomPreferences
+      mapCustomPreferences,
+      defaultDestinationBehavior
     } = this.props
     // TODO: add option to run mapCustomPreferences on load so that the destination preferences automatically get updated
     let { destinationPreferences, customPreferences } = loadPreferences()
@@ -193,7 +194,8 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       writeKey,
       destinations,
       destinationPreferences,
-      isConsentRequired
+      isConsentRequired,
+      defaultDestinationBehavior
     })
 
     this.setState({
@@ -232,7 +234,7 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
   }
 
   handleSaveConsent = (newPreferences: CategoryPreferences | undefined, shouldReload: boolean) => {
-    const { writeKey, cookieDomain, mapCustomPreferences } = this.props
+    const { writeKey, cookieDomain, mapCustomPreferences, defaultDestinationBehavior } = this.props
 
     this.setState(prevState => {
       const { destinations, preferences: existingPreferences, isConsentRequired } = prevState
@@ -270,7 +272,8 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
         destinations,
         destinationPreferences,
         isConsentRequired,
-        shouldReload
+        shouldReload,
+        defaultDestinationBehavior
       })
 
       return { ...prevState, destinationPreferences, preferences, newDestinations }

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -2,7 +2,12 @@ import { Component } from 'react'
 import { loadPreferences, savePreferences } from './preferences'
 import fetchDestinations from './fetch-destinations'
 import conditionallyLoadAnalytics from './analytics'
-import { Destination, CategoryPreferences, CustomCategories } from '../types'
+import {
+  Destination,
+  CategoryPreferences,
+  CustomCategories,
+  DefaultDestinationBehavior
+} from '../types'
 
 function getNewDestinations(destinations: Destination[], preferences: CategoryPreferences) {
   const newDestinations: Destination[] = []
@@ -57,6 +62,11 @@ interface Props {
    * Allows for adding custom consent categories by mapping a custom category to Segment integrations
    */
   customCategories?: CustomCategories
+
+  /**
+   * Specified default behavior for when new destinations are detected on the source(s) of this consent manager.
+   */
+  defaultDestinationBehavior?: DefaultDestinationBehavior
 
   /**
    * A callback for dealing with errors in the Consent Manager

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -181,7 +181,10 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
         v => v === null || v === undefined
       )
 
-      if (hasInitialPreferenceToTrue && emptyCustomPreferecences) {
+      if (
+        (hasInitialPreferenceToTrue && emptyCustomPreferecences) ||
+        defaultDestinationBehavior === 'imply'
+      ) {
         const mapped = mapCustomPreferences(destinations, preferences)
         destinationPreferences = mapped.destinationPreferences
         customPreferences = mapped.customPreferences

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -92,6 +92,7 @@ interface State {
   newDestinations: Destination[]
   preferences?: CategoryPreferences
   isConsentRequired: boolean
+  havePreferencesChanged: boolean
 }
 
 export default class ConsentManagerBuilder extends Component<Props, State> {
@@ -268,16 +269,18 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       }
 
       const newDestinations = getNewDestinations(destinations, destinationPreferences)
-
-      savePreferences({ destinationPreferences, customPreferences, cookieDomain })
-      conditionallyLoadAnalytics({
-        writeKey,
-        destinations,
-        destinationPreferences,
-        isConsentRequired,
-        shouldReload,
-        defaultDestinationBehavior
-      })
+      // If preferences haven't changed, don't reload the page as it's a disruptive experience for end-users
+      if (prevState.havePreferencesChanged || prevState.newDestinations.length > 0) {
+        savePreferences({ destinationPreferences, customPreferences, cookieDomain })
+        conditionallyLoadAnalytics({
+          writeKey,
+          destinations,
+          destinationPreferences,
+          isConsentRequired,
+          shouldReload,
+          defaultDestinationBehavior
+        })
+      }
 
       return { ...prevState, destinationPreferences, preferences, newDestinations }
     })

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -191,8 +191,7 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       const emptyCustomPreferecences = Object.values(customPreferences || {}).every(
         v => v === null || v === undefined
       )
-      console.log('defaultDestinationBehavior ', defaultDestinationBehavior)
-      console.log('workspaceAddedNewDestinations ', workspaceAddedNewDestinations)
+
       if (
         (hasInitialPreferenceToTrue && emptyCustomPreferecences) ||
         (defaultDestinationBehavior === 'imply' && workspaceAddedNewDestinations)
@@ -202,9 +201,8 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
         customPreferences = mapped.customPreferences
         savePreferences({ destinationPreferences, customPreferences, cookieDomain })
       }
-    } else {
-      preferences = destinationPreferences || initialPreferences
     }
+    preferences = destinationPreferences || initialPreferences
 
     conditionallyLoadAnalytics({
       writeKey,

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -201,9 +201,9 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
         customPreferences = mapped.customPreferences
         savePreferences({ destinationPreferences, customPreferences, cookieDomain })
       }
-    } else {
-      preferences = destinationPreferences || initialPreferences
     }
+
+    preferences = destinationPreferences || initialPreferences
 
     conditionallyLoadAnalytics({
       writeKey,

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -191,7 +191,8 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       const emptyCustomPreferecences = Object.values(customPreferences || {}).every(
         v => v === null || v === undefined
       )
-
+      console.log('defaultDestinationBehavior ', defaultDestinationBehavior)
+      console.log('workspaceAddedNewDestinations ', workspaceAddedNewDestinations)
       if (
         (hasInitialPreferenceToTrue && emptyCustomPreferecences) ||
         (defaultDestinationBehavior === 'imply' && workspaceAddedNewDestinations)
@@ -201,9 +202,9 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
         customPreferences = mapped.customPreferences
         savePreferences({ destinationPreferences, customPreferences, cookieDomain })
       }
+    } else {
+      preferences = destinationPreferences || initialPreferences
     }
-
-    preferences = destinationPreferences || initialPreferences
 
     conditionallyLoadAnalytics({
       writeKey,

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -161,7 +161,8 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       shouldRequireConsent = ConsentManagerBuilder.defaultProps.shouldRequireConsent,
       initialPreferences,
       mapCustomPreferences,
-      defaultDestinationBehavior
+      defaultDestinationBehavior,
+      cookieDomain
     } = this.props
     // TODO: add option to run mapCustomPreferences on load so that the destination preferences automatically get updated
     let { destinationPreferences, customPreferences } = loadPreferences()
@@ -194,6 +195,7 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       preferences = destinationPreferences || initialPreferences
     }
 
+    savePreferences({ destinationPreferences, customPreferences, cookieDomain })
     conditionallyLoadAnalytics({
       writeKey,
       destinations,

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -70,10 +70,6 @@ function normalizeDestinations(destinations: Destination[]) {
 }
 
 const Container: React.FC<ContainerProps> = props => {
-  console.log(
-    'Should open? ',
-    props.workspaceAddedNewDestinations && props.defaultDestinationBehavior === 'ask'
-  )
   const [isDialogOpen, toggleDialog] = React.useState(
     false || (props.workspaceAddedNewDestinations && props.defaultDestinationBehavior === 'ask')
   )

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -4,7 +4,12 @@ import Banner from './banner'
 import PreferenceDialog from './preference-dialog'
 import CancelDialog from './cancel-dialog'
 import { ADVERTISING_CATEGORIES, FUNCTIONAL_CATEGORIES } from './categories'
-import { Destination, CategoryPreferences, CustomCategories } from '../types'
+import {
+  Destination,
+  CategoryPreferences,
+  CustomCategories,
+  DefaultDestinationBehavior
+} from '../types'
 
 const emitter = new EventEmitter()
 export function openDialog() {
@@ -41,6 +46,7 @@ interface ContainerProps {
   preferencesDialogContent: React.ReactNode
   cancelDialogTitle: React.ReactNode
   cancelDialogContent: React.ReactNode
+  defaultDestinationBehavior?: DefaultDestinationBehavior
 }
 
 function normalizeDestinations(destinations: Destination[]) {
@@ -63,7 +69,9 @@ function normalizeDestinations(destinations: Destination[]) {
 }
 
 const Container: React.FC<ContainerProps> = props => {
-  const [isDialogOpen, toggleDialog] = React.useState(false)
+  const [isDialogOpen, toggleDialog] = React.useState(
+    false || (props.defaultDestinationBehavior === 'ask' && props.newDestinations.length > 0)
+  )
   const [showBanner, toggleBanner] = React.useState(true)
   const [isCancelling, toggleCancel] = React.useState(false)
 
@@ -147,10 +155,7 @@ const Container: React.FC<ContainerProps> = props => {
 
   const handleSave = () => {
     toggleDialog(false)
-    // If preferences haven't changed, don't reload the page as it's a disruptive experience for end-users
-    if (!props.havePreferencesChanged) {
-      return
-    }
+
     props.saveConsent()
   }
 

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -46,6 +46,7 @@ interface ContainerProps {
   preferencesDialogContent: React.ReactNode
   cancelDialogTitle: React.ReactNode
   cancelDialogContent: React.ReactNode
+  workspaceAddedNewDestinations?: boolean
   defaultDestinationBehavior?: DefaultDestinationBehavior
 }
 
@@ -69,8 +70,12 @@ function normalizeDestinations(destinations: Destination[]) {
 }
 
 const Container: React.FC<ContainerProps> = props => {
+  console.log(
+    'Should open? ',
+    props.workspaceAddedNewDestinations && props.defaultDestinationBehavior === 'ask'
+  )
   const [isDialogOpen, toggleDialog] = React.useState(
-    false || (props.defaultDestinationBehavior === 'ask' && props.newDestinations.length > 0)
+    false || (props.workspaceAddedNewDestinations && props.defaultDestinationBehavior === 'ask')
   )
   const [showBanner, toggleBanner] = React.useState(true)
   const [isCancelling, toggleCancel] = React.useState(false)

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -25,7 +25,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
     bannerBackgroundColor: '#1f4160',
     preferencesDialogTitle: 'Website Data Collection Preferences',
     cancelDialogTitle: 'Are you sure you want to cancel?',
-    defaultDestinationBehavior: 'disable'
+    defaultDestinationBehavior: 'ask'
   }
 
   render() {
@@ -93,6 +93,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
             cancelDialogTitle={cancelDialogTitle}
             cancelDialogContent={cancelDialogContent}
             havePreferencesChanged={havePreferencesChanged}
+            defaultDestinationBehavior={defaultDestinationBehavior}
           />
         }}
       </ConsentManagerBuilder>

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -25,7 +25,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
     bannerBackgroundColor: '#1f4160',
     preferencesDialogTitle: 'Website Data Collection Preferences',
     cancelDialogTitle: 'Are you sure you want to cancel?',
-    defaultDestinationBehavior: 'ask'
+    defaultDestinationBehavior: 'disable'
   }
 
   render() {
@@ -69,7 +69,8 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
           setPreferences,
           resetPreferences,
           saveConsent,
-          havePreferencesChanged
+          havePreferencesChanged,
+          workspaceAddedNewDestinations
         }) => {
           return <Container
             customCategories={customCategories}
@@ -94,6 +95,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
             cancelDialogContent={cancelDialogContent}
             havePreferencesChanged={havePreferencesChanged}
             defaultDestinationBehavior={defaultDestinationBehavior}
+            workspaceAddedNewDestinations={workspaceAddedNewDestinations}
           />
         }}
       </ConsentManagerBuilder>

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -24,7 +24,8 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
     bannerSubContent: 'You can change your preferences at any time.',
     bannerBackgroundColor: '#1f4160',
     preferencesDialogTitle: 'Website Data Collection Preferences',
-    cancelDialogTitle: 'Are you sure you want to cancel?'
+    cancelDialogTitle: 'Are you sure you want to cancel?',
+    defaultDestinationBehavior: 'disable'
   }
 
   render() {
@@ -43,6 +44,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
       cancelDialogTitle,
       cancelDialogContent,
       customCategories,
+      defaultDestinationBehavior,
       onError
     } = this.props
 
@@ -56,6 +58,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
         initialPreferences={this.getInitialPreferences()}
         mapCustomPreferences={this.handleMapCustomPreferences}
         customCategories={customCategories}
+        defaultDestinationBehavior={defaultDestinationBehavior}
       >
         {({
           destinations,

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,8 @@ export type ConsentManagerInput = ConsentManagerProps & {
   container: string
 }
 
+export type DefaultDestinationBehavior = 'enable' | 'disable' | 'imply' | 'ask'
+
 interface StandaloneConsentManagerParams {
   React: unknown
   version?: string
@@ -79,4 +81,5 @@ export interface ConsentManagerProps {
   closeBehavior?: CloseBehavior | CloseBehaviorFunction
   initialPreferences?: CategoryPreferences
   customCategories?: CustomCategories
+  defaultDestinationBehavior?: DefaultDestinationBehavior
 }

--- a/stories/7-default-destination-behavior.stories.tsx
+++ b/stories/7-default-destination-behavior.stories.tsx
@@ -95,20 +95,20 @@ const ConsentManagerExample = () => {
   const closeBehavior = inCA()
     ? _categories => caDefaultPreferences
     : inEU()
-      ? CloseBehavior.DENY
-      : CloseBehavior.ACCEPT
+    ? CloseBehavior.DENY
+    : CloseBehavior.ACCEPT
 
   const initialPreferences = inCA()
     ? caDefaultPreferences
     : inEU()
-      ? euDefaultPreferences
-      : undefined
+    ? euDefaultPreferences
+    : undefined
 
   return (
     <Pane>
       <ConsentManager
-        writeKey="tYQQPcY78Hc3T1hXUYk0n4xcbEHnN7r0"
-        otherWriteKeys={['vMRS7xbsjH97Bb2PeKbEKvYDvgMm5T3l']}
+        writeKey="VeSvGsFntmbyoQ3wh9FJphKGpPNW2paD"
+        otherWriteKeys={[]}
         bannerContent={bannerContent}
         bannerSubContent={bannerSubContent}
         preferencesDialogTitle={preferencesDialogTitle}

--- a/stories/7-default-destination-behavior.stories.tsx
+++ b/stories/7-default-destination-behavior.stories.tsx
@@ -7,7 +7,6 @@ import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs'
 import SyntaxHighlighter from 'react-syntax-highlighter'
 import { Preferences } from '../src/types'
 import CookieView from './components/CookieView'
-import inRegions from '@segment/in-regions'
 import { CloseBehavior } from '../src/consent-manager/container'
 
 const bannerContent = (
@@ -78,31 +77,6 @@ const ConsentManagerExample = () => {
     }
   })
 
-  const inCA = inRegions(['CA'])
-  const inEU = inRegions(['EU'])
-  const shouldRequireConsent = inRegions(['CA', 'EU'])
-  const caDefaultPreferences = {
-    advertising: false,
-    marketingAndAnalytics: true,
-    functional: true
-  }
-  const euDefaultPreferences = {
-    advertising: false,
-    marketingAndAnalytics: false,
-    functional: false
-  }
-
-  const closeBehavior = inCA()
-    ? _categories => caDefaultPreferences
-    : inEU()
-    ? CloseBehavior.DENY
-    : CloseBehavior.ACCEPT
-
-  const initialPreferences = inCA()
-    ? caDefaultPreferences
-    : inEU()
-    ? euDefaultPreferences
-    : undefined
 
   return (
     <Pane>
@@ -115,9 +89,7 @@ const ConsentManagerExample = () => {
         preferencesDialogContent={preferencesDialogContent}
         cancelDialogTitle={cancelDialogTitle}
         cancelDialogContent={cancelDialogContent}
-        closeBehavior={closeBehavior}
-        shouldRequireConsent={shouldRequireConsent}
-        initialPreferences={initialPreferences}
+        closeBehavior={CloseBehavior.ACCEPT}
       />
 
       <Pane marginX={100} marginTop={20}>

--- a/stories/7-default-destination-behavior.stories.tsx
+++ b/stories/7-default-destination-behavior.stories.tsx
@@ -1,0 +1,170 @@
+import React from 'react'
+import cookies from 'js-cookie'
+import { Pane, Heading, Paragraph, Button } from 'evergreen-ui'
+import { ConsentManager, openConsentManager, loadPreferences, onPreferencesSaved } from '../src'
+import { storiesOf } from '@storybook/react'
+import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs'
+import SyntaxHighlighter from 'react-syntax-highlighter'
+import { Preferences } from '../src/types'
+import CookieView from './components/CookieView'
+import inRegions from '@segment/in-regions'
+import { CloseBehavior } from '../src/consent-manager/container'
+
+const bannerContent = (
+  <span>
+    We use cookies (and other similar technologies) to collect data to improve your experience on
+    our site. By using our website, you’re agreeing to the collection of data as described in our{' '}
+    <a
+      href="https://segment.com/docs/legal/website-data-collection-policy/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Website Data Collection Policy
+    </a>
+    .
+  </span>
+)
+const bannerSubContent = 'You can manage your preferences here!'
+const preferencesDialogTitle = 'Website Data Collection Preferences'
+const preferencesDialogContent = (
+  <div>
+    <p>
+      Segment uses data collected by cookies and JavaScript libraries to improve your browsing
+      experience, analyze site traffic, deliver personalized advertisements, and increase the
+      overall performance of our site.
+    </p>
+    <p>
+      By using our website, you’re agreeing to our{' '}
+      <a
+        href="https://segment.com/docs/legal/website-data-collection-policy/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Website Data Collection Policy
+      </a>
+      .
+    </p>
+    <p>
+      The table below outlines how we use this data by category. To opt out of a category of data
+      collection, select “No” and save your preferences.
+    </p>
+  </div>
+)
+const cancelDialogTitle = 'Are you sure you want to cancel?'
+const cancelDialogContent = (
+  <div>
+    Your preferences have not been saved. By continuing to use our website, you’re agreeing to our{' '}
+    <a
+      href="https://segment.com/docs/legal/website-data-collection-policy/"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Website Data Collection Policy
+    </a>
+    .
+  </div>
+)
+
+const ConsentManagerExample = () => {
+  const [prefs, updatePrefs] = React.useState<Preferences>(loadPreferences())
+
+  const cleanup = onPreferencesSaved(preferences => {
+    updatePrefs(preferences)
+  })
+
+  React.useEffect(() => {
+    return () => {
+      cleanup()
+    }
+  })
+
+  const inCA = inRegions(['CA'])
+  const inEU = inRegions(['EU'])
+  const shouldRequireConsent = inRegions(['CA', 'EU'])
+  const caDefaultPreferences = {
+    advertising: false,
+    marketingAndAnalytics: true,
+    functional: true
+  }
+  const euDefaultPreferences = {
+    advertising: false,
+    marketingAndAnalytics: false,
+    functional: false
+  }
+
+  const closeBehavior = inCA()
+    ? _categories => caDefaultPreferences
+    : inEU()
+      ? CloseBehavior.DENY
+      : CloseBehavior.ACCEPT
+
+  const initialPreferences = inCA()
+    ? caDefaultPreferences
+    : inEU()
+      ? euDefaultPreferences
+      : undefined
+
+  return (
+    <Pane>
+      <ConsentManager
+        writeKey="tYQQPcY78Hc3T1hXUYk0n4xcbEHnN7r0"
+        otherWriteKeys={['vMRS7xbsjH97Bb2PeKbEKvYDvgMm5T3l']}
+        bannerContent={bannerContent}
+        bannerSubContent={bannerSubContent}
+        preferencesDialogTitle={preferencesDialogTitle}
+        preferencesDialogContent={preferencesDialogContent}
+        cancelDialogTitle={cancelDialogTitle}
+        cancelDialogContent={cancelDialogContent}
+        closeBehavior={closeBehavior}
+        shouldRequireConsent={shouldRequireConsent}
+        initialPreferences={initialPreferences}
+      />
+
+      <Pane marginX={100} marginTop={20}>
+        <Heading> Cute Cats </Heading>
+        <Pane display="flex">
+          <iframe
+            src="https://giphy.com/embed/JIX9t2j0ZTN9S"
+            width="480"
+            height="480"
+            frameBorder="0"
+          />
+
+          <iframe
+            src="https://giphy.com/embed/yFQ0ywscgobJK"
+            width="398"
+            height="480"
+            frameBorder="0"
+          />
+        </Pane>
+
+        <Paragraph marginTop={20}>
+          This example highlights checking for EU or CA residency, then changing the closeBehavior
+          based on membership in each.
+        </Paragraph>
+        <p>
+          <div>
+            <Heading>Current Preferences</Heading>
+            <SyntaxHighlighter language="json" style={docco}>
+              {JSON.stringify(prefs, null, 2)}
+            </SyntaxHighlighter>
+          </div>
+          <Button marginRight={20} onClick={openConsentManager}>
+            Change Cookie Preferences
+          </Button>
+          <Button
+            onClick={() => {
+              cookies.remove('tracking-preferences')
+              window.location.reload()
+            }}
+          >
+            Clear
+          </Button>
+        </p>
+      </Pane>
+      <CookieView />
+    </Pane>
+  )
+}
+
+storiesOf('Default Destination Behavior', module).add(`disable`, () => <ConsentManagerExample />)

--- a/stories/7-default-destination-behavior.stories.tsx
+++ b/stories/7-default-destination-behavior.stories.tsx
@@ -85,7 +85,7 @@ const ConsentManagerExample = (props: {
   defaultDestinationBehavior: DefaultDestinationBehavior
 }) => {
   const [prefs, updatePrefs] = React.useState<Preferences>(loadPreferences())
-  console.log('prefs ', prefs)
+
   const cleanup = onPreferencesSaved(preferences => {
     updatePrefs(preferences)
   })

--- a/stories/7-default-destination-behavior.stories.tsx
+++ b/stories/7-default-destination-behavior.stories.tsx
@@ -5,9 +5,26 @@ import { ConsentManager, openConsentManager, loadPreferences, onPreferencesSaved
 import { storiesOf } from '@storybook/react'
 import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs'
 import SyntaxHighlighter from 'react-syntax-highlighter'
-import { Preferences } from '../src/types'
+import { Preferences, DefaultDestinationBehavior } from '../src/types'
 import CookieView from './components/CookieView'
 import { CloseBehavior } from '../src/consent-manager/container'
+
+cookies.set(
+  'tracking-preferences',
+  JSON.stringify({
+    destinations: {
+      Amplitude: true,
+      'Customer.io': true,
+      'Google Analytics': true,
+      Webhooks: true
+    },
+    custom: {
+      advertising: false,
+      marketingAndAnalytics: true,
+      functional: true
+    }
+  })
+)
 
 const bannerContent = (
   <span>
@@ -64,9 +81,11 @@ const cancelDialogContent = (
   </div>
 )
 
-const ConsentManagerExample = () => {
+const ConsentManagerExample = (props: {
+  defaultDestinationBehavior: DefaultDestinationBehavior
+}) => {
   const [prefs, updatePrefs] = React.useState<Preferences>(loadPreferences())
-
+  console.log('prefs ', prefs)
   const cleanup = onPreferencesSaved(preferences => {
     updatePrefs(preferences)
   })
@@ -76,7 +95,6 @@ const ConsentManagerExample = () => {
       cleanup()
     }
   })
-
 
   return (
     <Pane>
@@ -90,6 +108,7 @@ const ConsentManagerExample = () => {
         cancelDialogTitle={cancelDialogTitle}
         cancelDialogContent={cancelDialogContent}
         closeBehavior={CloseBehavior.ACCEPT}
+        defaultDestinationBehavior={props.defaultDestinationBehavior}
       />
 
       <Pane marginX={100} marginTop={20}>
@@ -111,8 +130,9 @@ const ConsentManagerExample = () => {
         </Pane>
 
         <Paragraph marginTop={20}>
-          This example highlights checking for EU or CA residency, then changing the closeBehavior
-          based on membership in each.
+          This example highlights default destination behavior. The cookie set is missing a
+          destination that is enabled on the source, imitating a newly added destination. In the
+          console, verify behavior by looking at analytics.options.
         </Paragraph>
         <p>
           <div>
@@ -126,11 +146,10 @@ const ConsentManagerExample = () => {
           </Button>
           <Button
             onClick={() => {
-              cookies.remove('tracking-preferences')
               window.location.reload()
             }}
           >
-            Clear
+            Reset Example
           </Button>
         </p>
       </Pane>
@@ -139,4 +158,15 @@ const ConsentManagerExample = () => {
   )
 }
 
-storiesOf('Default Destination Behavior', module).add(`disable`, () => <ConsentManagerExample />)
+storiesOf('Default Destination Behavior', module).add(`disable`, () => (
+  <ConsentManagerExample defaultDestinationBehavior="disable" />
+))
+storiesOf('Default Destination Behavior', module).add(`enable`, () => (
+  <ConsentManagerExample defaultDestinationBehavior="enable" />
+))
+storiesOf('Default Destination Behavior', module).add(`imply`, () => (
+  <ConsentManagerExample defaultDestinationBehavior="imply" />
+))
+storiesOf('Default Destination Behavior', module).add(`ask`, () => (
+  <ConsentManagerExample defaultDestinationBehavior="ask" />
+))


### PR DESCRIPTION
# Allow users to set default behavior when new destinations are added
Right now, when our customers add a new destination to a source w/ consent manager, and the end-user has a cookie set already on the browser, that destination is set to `false`.

This PR adds a new prop that allows customers to specify behavior - they can by default:
- **enable**: enable new destinations
- **disable**: disable new destinations
- **ask**: re-prompt customers to give consent
- **imply**: enable/disable the new destination based on the end-user's preference for the consent group that the new destination belongs to

Other changes made by this PR:
- amends behavior introduced in https://github.com/segmentio/consent-manager/pull/86 - which makes sure the page does not reload after hitting "Save" if no destination preferences have been modified.

-  amends `initialPreference` behavior. 
    - **Before this PR:** initialPreferences are respected by analytics.js, but are not saved to the cookie
    - **After this PR:** initialPreferences are respected by analytics.js, and are saved to the cookie (for parity between what is happening in a.js and what the cookie says is happening)

## Test Case
Initially, only three destinations are connected to the source:
<img width="284" alt="Screen Shot 2020-04-02 at 10 21 26 PM" src="https://user-images.githubusercontent.com/31225471/78326989-96f8f700-7530-11ea-902d-2956d0dbdcca.png">

### ask
If `defaultDestinationBehavior` is set to `ask`, a model will appear when consent manager detects that a new destination was added to the source, that is not on the existing cookie. 

In this case, Mixpanel is an added destination that is _not_ on the cookie (above):
<img width="716" alt="Screen Shot 2020-04-02 at 10 22 46 PM" src="https://user-images.githubusercontent.com/31225471/78327052-cc9de000-7530-11ea-8d9e-211a422ab9fe.png">

### disable
`disable` sets all new destinations that are not already on the cookie to false (not loaded).

For the above example, you can see that Mixpanel was set to false for the analytics load options:
![Screen Shot 2020-04-02 at 10 27 38 PM](https://user-images.githubusercontent.com/31225471/78327311-61a0d900-7531-11ea-9e70-0e3d0df8621d.png)

### enable
`enable` sets all new destinations that are not already on the cookie to true (they are loaded by default). This is the least privacy forward option.

For the above test, see that Mixpanel is now set to true upon loading the page:
![Screen Shot 2020-04-02 at 10 30 49 PM](https://user-images.githubusercontent.com/31225471/78327416-b0e70980-7531-11ea-940f-e06244e7d11b.png)

### imply
`imply` sets true/false on the new integration based on the user's consent to the consent group the integration would fall under.

For the above test, Mixpanel is set to true because the cookie already has `marketingAndAnalytics: true`:
![Screen Shot 2020-04-02 at 10 39 19 PM](https://user-images.githubusercontent.com/31225471/78327965-e3453680-7532-11ea-82f0-81364d75e4ff.png)

This is also set on the cookie:
<img width="264" alt="Screen Shot 2020-04-02 at 10 38 48 PM" src="https://user-images.githubusercontent.com/31225471/78327944-dc1e2880-7532-11ea-98f0-e80bdf6e326b.png">

## README Updates
The README is updated with information about the new prop:
<img width="954" alt="Screen Shot 2020-04-03 at 2 15 02 PM" src="https://user-images.githubusercontent.com/31225471/78405559-9787a100-75b5-11ea-95e8-28bf3450d724.png">
