### PR TITLE
Fix UI rendering of initialPreferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,13 @@ Default: `{}`
 
 The current preferences in state. By default if should be in the format of `{destinationId: true|false}`, but if you're using [mapCustomPreferences][] the object map can be in any format you want. _Note: this isn't the saved preferences._
 
+##### destinationPreferences
+
+Type: `object`<br>
+Default: `{}`
+
+The current _destination specific_ preferences, i.e. `{Amplitude: true}`.
+
 ##### havePreferencesChanged
 
 Type: `boolean`<br>

--- a/src/__tests__/consent-manager-builder/index.todo.js
+++ b/src/__tests__/consent-manager-builder/index.todo.js
@@ -234,7 +234,7 @@ describe('ConsentManagerBuilder', () => {
         }}
       >
         {({ destinationPreferences }) => {
-          expect(preferences).toMatchObject({
+          expect(destinationPreferences).toMatchObject({
             Amplitude: true,
             'Google Analytics': true
           })
@@ -309,7 +309,7 @@ describe('ConsentManagerBuilder', () => {
         }}
       >
         {({ destinationPreferences }) => {
-          expect(preferences).toMatchObject({
+          expect(destinationPreferences).toMatchObject({
             Amplitude: false,
             'Google Analytics': false
           })

--- a/src/__tests__/consent-manager-builder/index.todo.js
+++ b/src/__tests__/consent-manager-builder/index.todo.js
@@ -233,7 +233,7 @@ describe('ConsentManagerBuilder', () => {
           return { destinationPreferences, customPreferences }
         }}
       >
-        {({ preferences }) => {
+        {({ destinationPreferences }) => {
           expect(preferences).toMatchObject({
             Amplitude: true,
             'Google Analytics': true
@@ -308,7 +308,7 @@ describe('ConsentManagerBuilder', () => {
           return { destinationPreferences, customPreferences }
         }}
       >
-        {({ preferences }) => {
+        {({ destinationPreferences }) => {
           expect(preferences).toMatchObject({
             Amplitude: false,
             'Google Analytics': false

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -78,6 +78,7 @@ interface RenderProps {
   destinations: Destination[]
   newDestinations: Destination[]
   preferences: CategoryPreferences
+  destinationPreferences: CategoryPreferences
   isConsentRequired: boolean
   customCategories?: CustomCategories
   havePreferencesChanged: boolean
@@ -92,6 +93,7 @@ interface State {
   destinations: Destination[]
   newDestinations: Destination[]
   preferences?: CategoryPreferences
+  destinationPreferences?: CategoryPreferences
   isConsentRequired: boolean
   havePreferencesChanged: boolean
   workspaceAddedNewDestinations: boolean
@@ -112,6 +114,7 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
     destinations: [],
     newDestinations: [],
     preferences: {},
+    destinationPreferences: {},
     isConsentRequired: true,
     havePreferencesChanged: false,
     workspaceAddedNewDestinations: false
@@ -126,7 +129,8 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       newDestinations,
       isConsentRequired,
       havePreferencesChanged,
-      workspaceAddedNewDestinations
+      workspaceAddedNewDestinations,
+      destinationPreferences
     } = this.state
     if (isLoading) {
       return null
@@ -140,6 +144,7 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       isConsentRequired,
       havePreferencesChanged,
       workspaceAddedNewDestinations,
+      destinationPreferences,
       setPreferences: this.handleSetPreferences,
       resetPreferences: this.handleResetPreferences,
       saveConsent: this.handleSaveConsent
@@ -219,6 +224,7 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       newDestinations,
       preferences,
       isConsentRequired,
+      destinationPreferences,
       workspaceAddedNewDestinations: Boolean(workspaceAddedNewDestinations)
     })
   }

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -201,8 +201,9 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
         customPreferences = mapped.customPreferences
         savePreferences({ destinationPreferences, customPreferences, cookieDomain })
       }
+    } else {
+      preferences = destinationPreferences || initialPreferences
     }
-    preferences = destinationPreferences || initialPreferences
 
     conditionallyLoadAnalytics({
       writeKey,

--- a/stories/7-default-destination-behavior.stories.tsx
+++ b/stories/7-default-destination-behavior.stories.tsx
@@ -9,23 +9,6 @@ import { Preferences, DefaultDestinationBehavior } from '../src/types'
 import CookieView from './components/CookieView'
 import { CloseBehavior } from '../src/consent-manager/container'
 
-cookies.set(
-  'tracking-preferences',
-  JSON.stringify({
-    destinations: {
-      Amplitude: true,
-      'Customer.io': true,
-      'Google Analytics': true,
-      Webhooks: true
-    },
-    custom: {
-      advertising: false,
-      marketingAndAnalytics: true,
-      functional: true
-    }
-  })
-)
-
 const bannerContent = (
   <span>
     We use cookies (and other similar technologies) to collect data to improve your experience on
@@ -85,6 +68,25 @@ const ConsentManagerExample = (props: {
   defaultDestinationBehavior: DefaultDestinationBehavior
 }) => {
   const [prefs, updatePrefs] = React.useState<Preferences>(loadPreferences())
+
+  React.useEffect(() => {
+    cookies.set(
+      'tracking-preferences',
+      JSON.stringify({
+        destinations: {
+          Amplitude: true,
+          'Customer.io': true,
+          'Google Analytics': true,
+          Webhooks: true
+        },
+        custom: {
+          advertising: false,
+          marketingAndAnalytics: true,
+          functional: true
+        }
+      })
+    )
+  })
 
   const cleanup = onPreferencesSaved(preferences => {
     updatePrefs(preferences)


### PR DESCRIPTION
There was a UI regression in the last version `4.5.0` with `initialPreferences`. If the user had `initialPreferences` set:
1. On opening the dialog the first time, the initial preferences would not be reflected in the UI
2. Hit 'cancel'
3. On opening the dialog the second time, the initial preferences are now reflected

This was purely a UI bug, and initial preferences were still respected by `analytics.js`. The root of the issue was that the `preferences` object passed to the dialog component on _initialization_ was incorrect, but the object would be corrected on "Cancel" or any interaction with the dialog - correcting the issue the 2nd time the dialog was opened. 

**Test**
This gif is taken of a consent manager implementation for CCPA, where there are `initialPreferences` set. Note that the initialPreferences are reflected on the first render:
![blip1](https://user-images.githubusercontent.com/31225471/79491369-37d8bf00-7fd3-11ea-8c61-8c7e31ac5c34.gif)
