### PR TITLE
Expose analytics instance as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ At its core, the Consent Manager empowers your visitors to control and customize
 
 It works by taking control of the analytics.js load process to only load destinations that the user has consented to and not loading analytics.js at all if the user has opted out of everything. The user's tracking preferences are saved to a cookie and sent as an identify trait (if they haven't opted out of everything) so that you can also access them on the server-side and from destinations (warehouse).
 
-*Segment works to ensure the Consent Manager Tech Demo works with most of our product pipeline. We cannot ensure it works in your specific implementation or website. Please contact our Professional Services team for implementation support. Please see the License.txt included.*
+_Segment works to ensure the Consent Manager Tech Demo works with most of our product pipeline. We cannot ensure it works in your specific implementation or website. Please contact our Professional Services team for implementation support. Please see the License.txt included._
 
 ### Features
 
@@ -27,6 +27,7 @@ It works by taking control of the analytics.js load process to only load destina
 - **5.0.0**: Consent Manager will add consent metadata to the context of all track calls:
 
 Track call message payloads will be extended to include Consent metadata in the `context` object:
+
 ```
 {
   "context": {
@@ -58,7 +59,8 @@ Track call message payloads will be extended to include Consent metadata in the 
 }
 ```
 
-**Breaking Changes:** Version 5.0.0 and above require that your analytics.js snippet include the method `addSourceMiddleware` in the `analytics.methods` array: 
+**Breaking Changes:** Version 5.0.0 and above require that your analytics.js snippet include the method `addSourceMiddleware` in the `analytics.methods` array:
+
 ```
 analytics.methods = [
   'trackSubmit',
@@ -343,6 +345,13 @@ const customCategories = {
 
 The values for `integrations` should be an integration's creationName (`integration.creationName`). You can find examples of that by going to `https://cdn.segment.com/v1/projects/<writeKey>/integrations`
 
+##### analytics
+
+Type `SegmentAnalytics.AnalyticsJS`<br>
+Default: `window.analytics`
+
+The analytics instance you want the consent manager to connect to. By default, the analytics instance is stored at `window.analytics`. This prop is an escape hatch which allows this to be customised if necessary.
+
 #### Example
 
 ```javascript
@@ -443,7 +452,7 @@ Options:
 - `imply` - Newly detected destinations are by default, enabled or disabled, depending on the user's consent to the consent group that the new destination belongs to.
   - For example, if a user has already consented to the "marketingAndAnalytics" category, and we detect a new destination with category "Analytics", that destination will be enabled.
 
-This setting will also also affect replays to new destinations. Only `disable` and `enable` will apply to these replays. Setting `defaultDestinationBehavior` to `imply` here will be interpreted as `enable` during a replay. 
+This setting will also also affect replays to new destinations. Only `disable` and `enable` will apply to these replays. Setting `defaultDestinationBehavior` to `imply` here will be interpreted as `enable` during a replay.
 
 ##### mapCustomPreferences
 
@@ -458,6 +467,13 @@ Type: `string`<br>
 Default: the [top most domain][top-domain] and all sub domains
 
 The domain the `tracking-preferences` cookie should be scoped to.
+
+##### analytics
+
+Type `SegmentAnalytics.AnalyticsJS`<br>
+Default: `window.analytics`
+
+The analytics instance you want the consent manager to connect to. By default, the analytics instance is stored at `window.analytics`. This prop is an escape hatch which allows this to be customised if necessary.
 
 #### Render Props
 

--- a/src/__tests__/consent-manager-builder/analytics.test.ts
+++ b/src/__tests__/consent-manager-builder/analytics.test.ts
@@ -253,4 +253,54 @@ describe('analytics', () => {
       }
     })
   })
+
+  test('should support multiple instances when passed in manually', () => {
+    const windowAjsLoad = sinon.spy()
+    wd.analytics.load = windowAjsLoad
+    const analytics = {
+      ...wd.analytics,
+      load: sinon.spy()
+    }
+    const writeKey = '123'
+    const destinations = [{ id: 'Amplitude' } as Destination]
+    const destinationPreferences = {
+      Amplitude: true
+    }
+
+    conditionallyLoadAnalytics({
+      writeKey,
+      destinations,
+      destinationPreferences,
+      isConsentRequired: true,
+      categoryPreferences: {}
+    })
+    conditionallyLoadAnalytics({
+      analytics,
+      writeKey,
+      destinations,
+      destinationPreferences,
+      isConsentRequired: true,
+      categoryPreferences: {}
+    })
+
+    expect(windowAjsLoad.calledOnce).toBe(true)
+    expect(windowAjsLoad.args[0][0]).toBe(writeKey)
+    expect(windowAjsLoad.args[0][1]).toMatchObject({
+      integrations: {
+        All: false,
+        Amplitude: true,
+        'Segment.io': true
+      }
+    })
+
+    expect(analytics.load.calledOnce).toBe(true)
+    expect(analytics.load.args[0][0]).toBe(writeKey)
+    expect(analytics.load.args[0][1]).toMatchObject({
+      integrations: {
+        All: false,
+        Amplitude: true,
+        'Segment.io': true
+      }
+    })
+  })
 })

--- a/src/__tests__/consent-manager-builder/preferences.test.ts
+++ b/src/__tests__/consent-manager-builder/preferences.test.ts
@@ -93,4 +93,45 @@ describe('preferences', () => {
     // TODO: actually check domain
     // expect(document.cookie.includes('domain=example.com')).toBe(true)
   })
+
+  test('savePreferences() saves to the specified instance when defined', () => {
+    const windowAjsIdentify = sinon.spy()
+
+    // @ts-ignore
+    window.analytics = { identify: windowAjsIdentify }
+    document.cookie = ''
+
+    const analytics = {
+      ...window.analytics,
+      identify: sinon.spy()
+    }
+
+    const destinationPreferences = {
+      Amplitude: true
+    }
+    const customPreferences = {
+      functional: true
+    }
+
+    savePreferences({
+      analytics,
+      destinationPreferences,
+      customPreferences,
+      cookieDomain: undefined
+    })
+
+    expect(analytics.identify.calledOnce).toBe(true)
+    expect(analytics.identify.args[0][0]).toMatchObject({
+      destinationTrackingPreferences: destinationPreferences,
+      customTrackingPreferences: customPreferences
+    })
+
+    expect(windowAjsIdentify.calledOnce).toBe(false)
+
+    expect(
+      document.cookie.includes(
+        'tracking-preferences={%22version%22:1%2C%22destinations%22:{%22Amplitude%22:true}%2C%22custom%22:{%22functional%22:true}}'
+      )
+    ).toBe(true)
+  })
 })

--- a/src/consent-manager-builder/analytics.ts
+++ b/src/consent-manager-builder/analytics.ts
@@ -1,5 +1,5 @@
 import {
-  WindowWithAJS,
+  AnalyticsJS,
   Destination,
   DefaultDestinationBehavior,
   CategoryPreferences,
@@ -7,6 +7,7 @@ import {
 } from '../types'
 
 interface AnalyticsParams {
+  analytics?: AnalyticsJS
   writeKey: string
   destinations: Destination[]
   destinationPreferences: CategoryPreferences | null | undefined
@@ -32,6 +33,7 @@ function getConsentMiddleware(
 }
 
 export default function conditionallyLoadAnalytics({
+  analytics = window.analytics,
   writeKey,
   destinations,
   destinationPreferences,
@@ -40,7 +42,6 @@ export default function conditionallyLoadAnalytics({
   defaultDestinationBehavior,
   categoryPreferences
 }: AnalyticsParams) {
-  const wd = window as WindowWithAJS
   const integrations = { All: false, 'Segment.io': true }
   let isAnythingEnabled = false
 
@@ -50,8 +51,8 @@ export default function conditionallyLoadAnalytics({
     }
 
     // Load a.js normally when consent isn't required and there's no preferences
-    if (!wd.analytics.initialized) {
-      wd.analytics.load(writeKey)
+    if (!analytics.initialized) {
+      analytics.load(writeKey)
     }
     return
   }
@@ -73,7 +74,7 @@ export default function conditionallyLoadAnalytics({
 
   // Reload the page if the trackers have already been initialised so that
   // the user's new preferences can take affect
-  if (wd.analytics && wd.analytics.initialized) {
+  if (analytics && analytics.initialized) {
     if (shouldReload) {
       window.location.reload()
     }
@@ -88,8 +89,8 @@ export default function conditionallyLoadAnalytics({
       defaultDestinationBehavior
     )
     // @ts-ignore: Analytics.JS type should be updated with addSourceMiddleware
-    wd.analytics.addSourceMiddleware(middleware)
+    analytics.addSourceMiddleware(middleware)
 
-    wd.analytics.load(writeKey, { integrations })
+    analytics.load(writeKey, { integrations })
   }
 }

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -27,6 +27,12 @@ function getNewDestinations(destinations: Destination[], preferences: CategoryPr
 }
 
 interface Props {
+  /**
+   * Your segment analytics instance, for use when your instance is stored
+   * somewhere other than window.analytics.
+   */
+  analytics?: SegmentAnalytics.AnalyticsJS
+
   /** Your Segment Write key for your website */
   writeKey: string
 
@@ -103,6 +109,7 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
   static displayName = 'ConsentManagerBuilder'
 
   static defaultProps = {
+    analytics: window.analytics,
     otherWriteKeys: [],
     onError: undefined,
     shouldRequireConsent: () => true,
@@ -166,6 +173,7 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
 
   initialise = async () => {
     const {
+      analytics,
       writeKey,
       otherWriteKeys = ConsentManagerBuilder.defaultProps.otherWriteKeys,
       shouldRequireConsent = ConsentManagerBuilder.defaultProps.shouldRequireConsent,
@@ -203,13 +211,14 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
         const mapped = mapCustomPreferences(destinations, preferences)
         destinationPreferences = mapped.destinationPreferences
         customPreferences = mapped.customPreferences
-        savePreferences({ destinationPreferences, customPreferences, cookieDomain })
+        savePreferences({ analytics, destinationPreferences, customPreferences, cookieDomain })
       }
     } else {
       preferences = destinationPreferences || initialPreferences
     }
 
     conditionallyLoadAnalytics({
+      analytics,
       writeKey,
       destinations,
       destinationPreferences,
@@ -256,7 +265,13 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
   }
 
   handleSaveConsent = (newPreferences: CategoryPreferences | undefined, shouldReload: boolean) => {
-    const { writeKey, cookieDomain, mapCustomPreferences, defaultDestinationBehavior } = this.props
+    const {
+      analytics,
+      writeKey,
+      cookieDomain,
+      mapCustomPreferences,
+      defaultDestinationBehavior
+    } = this.props
 
     this.setState(prevState => {
       const { destinations, preferences: existingPreferences, isConsentRequired } = prevState
@@ -290,8 +305,9 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
 
       // If preferences haven't changed, don't reload the page as it's a disruptive experience for end-users
       if (prevState.havePreferencesChanged || newDestinations.length > 0) {
-        savePreferences({ destinationPreferences, customPreferences, cookieDomain })
+        savePreferences({ analytics, destinationPreferences, customPreferences, cookieDomain })
         conditionallyLoadAnalytics({
+          analytics,
           writeKey,
           destinations,
           destinationPreferences,

--- a/src/consent-manager-builder/preferences.ts
+++ b/src/consent-manager-builder/preferences.ts
@@ -1,7 +1,7 @@
 // TODO: remove duplicate cookie library from bundle
 import cookies from 'js-cookie'
 import topDomain from '@segment/top-domain'
-import { WindowWithAJS, Preferences, CategoryPreferences } from '../types'
+import { AnalyticsJS, Preferences, CategoryPreferences } from '../types'
 import { EventEmitter } from 'events'
 
 const COOKIE_KEY = 'tracking-preferences'
@@ -29,7 +29,7 @@ export function loadPreferences(): Preferences {
   }
 }
 
-type SavePreferences = Preferences & { cookieDomain?: string }
+type SavePreferences = Preferences & { analytics?: AnalyticsJS; cookieDomain?: string }
 
 const emitter = new EventEmitter()
 
@@ -45,13 +45,13 @@ export function onPreferencesSaved(listener: (prefs: Preferences) => void) {
 }
 
 export function savePreferences({
+  analytics = window.analytics,
   destinationPreferences,
   customPreferences,
   cookieDomain
 }: SavePreferences) {
-  const wd = window as WindowWithAJS
-  if (wd.analytics) {
-    wd.analytics.identify({
+  if (analytics) {
+    analytics.identify({
       destinationTrackingPreferences: destinationPreferences,
       customTrackingPreferences: customPreferences
     })

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -14,6 +14,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
   static displayName = 'ConsentManager'
 
   static defaultProps = {
+    analytics: window.analytics,
     otherWriteKeys: [],
     shouldRequireConsent: () => true,
     implyConsentOnInteraction: false,
@@ -30,6 +31,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
 
   render() {
     const {
+      analytics,
       writeKey,
       otherWriteKeys,
       shouldRequireConsent,
@@ -50,6 +52,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
 
     return (
       <ConsentManagerBuilder
+        analytics={analytics}
         onError={onError}
         writeKey={writeKey}
         otherWriteKeys={otherWriteKeys}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,10 @@
 import { CloseBehavior, CloseBehaviorFunction } from './consent-manager/container'
 import { PreferencesManager } from './consent-manager-builder/preferences'
 
-type AJS = SegmentAnalytics.AnalyticsJS & {
-  initialized: boolean
-  track: (event: string, properties: { [key: string]: any }) => void
-  addSourceMiddleware: (middleware: Middleware) => void
+export type AnalyticsJS = SegmentAnalytics.AnalyticsJS & {
+  initialized?: boolean
+  track?: (event: string, properties: { [key: string]: any }) => void
+  addSourceMiddleware?: (middleware: Middleware) => void
 }
 
 export type Middleware = (input: MiddlewareInput) => void
@@ -16,11 +16,6 @@ interface MiddlewareInput {
   integrations?: Record<string, boolean>
   next: (payload: MiddlewareInput['payload']) => void
 }
-
-export type WindowWithAJS = Window &
-  typeof globalThis & {
-    analytics?: AJS
-  }
 
 export type WindowWithConsentManagerConfig = Window &
   typeof globalThis & {
@@ -76,6 +71,7 @@ interface CustomCategory {
 }
 
 export interface ConsentManagerProps {
+  analytics?: SegmentAnalytics.AnalyticsJS
   writeKey: string
   otherWriteKeys?: string[]
   shouldRequireConsent?: () => Promise<boolean> | boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,11 @@ export type AnalyticsJS = SegmentAnalytics.AnalyticsJS & {
   addSourceMiddleware?: (middleware: Middleware) => void
 }
 
+export type WindowWithAJS = Window &
+  typeof globalThis & {
+    analytics?: AnalyticsJS
+  }
+
 export type Middleware = (input: MiddlewareInput) => void
 interface MiddlewareInput {
   payload: {


### PR DESCRIPTION
Hey! We're using segment on our website editor, and we're seeing some broken behaviour when our users also install (another instance of) segment for their own use on their website. In certain situations, events dispatched from our editor are visible on the user's segment dashboard.

A simple solution to this would be for us to store our `window.analytics` instance somewhere else (i.e. just rename it to `window.editorAnalytics` or similar). However, this option is currently blocked by the consent manager component, which reads from `window.analytics` directly.

This PR adds support for multi-instance via an optional `analytics` prop, which expects an analytics instance. If the user does not explicitly add an instance, it falls back to `window.analytics`, so this should be a non-breaking change.

Happy to tweak the approach if you'd prefer something different. Looks like the git hooks applied some extra formatting too... hope that's okay! 🤔 