### PR TITLE
added cdnHost

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ At its core, the Consent Manager empowers your visitors to control and customize
 
 It works by taking control of the analytics.js load process to only load destinations that the user has consented to and not loading analytics.js at all if the user has opted out of everything. The user's tracking preferences are saved to a cookie and sent as an identify trait (if they haven't opted out of everything) so that you can also access them on the server-side and from destinations (warehouse).
 
-*Segment works to ensure the Consent Manager Tech Demo works with most of our product pipeline. We cannot ensure it works in your specific implementation or website. Please contact our Professional Services team for implementation support. Please see the License.txt included.*
+_Segment works to ensure the Consent Manager Tech Demo works with most of our product pipeline. We cannot ensure it works in your specific implementation or website. Please contact our Professional Services team for implementation support. Please see the License.txt included._
 
 ### Features
 
@@ -27,6 +27,7 @@ It works by taking control of the analytics.js load process to only load destina
 - **5.0.0**: Consent Manager will add consent metadata to the context of all track calls:
 
 Track call message payloads will be extended to include Consent metadata in the `context` object:
+
 ```
 {
   "context": {
@@ -58,7 +59,8 @@ Track call message payloads will be extended to include Consent metadata in the 
 }
 ```
 
-**Breaking Changes:** Version 5.0.0 and above require that your analytics.js snippet include the method `addSourceMiddleware` in the `analytics.methods` array: 
+**Breaking Changes:** Version 5.0.0 and above require that your analytics.js snippet include the method `addSourceMiddleware` in the `analytics.methods` array:
+
 ```
 analytics.methods = [
   'trackSubmit',
@@ -390,6 +392,13 @@ export default function() {
 }
 ```
 
+##### cdnHost
+
+Type: `string`<br>
+Default: `cdn.segment.com`
+
+The CDN to fetch list of integrations from
+
 ### ConsentManagerBuilder
 
 The `ConsentManagerBuilder` React component is a low level render props component for building your own consent manager UI. It abstracts away all the logic for fetching destinations, checking/saving consent and loading analytics.js.
@@ -443,7 +452,7 @@ Options:
 - `imply` - Newly detected destinations are by default, enabled or disabled, depending on the user's consent to the consent group that the new destination belongs to.
   - For example, if a user has already consented to the "marketingAndAnalytics" category, and we detect a new destination with category "Analytics", that destination will be enabled.
 
-This setting will also also affect replays to new destinations. Only `disable` and `enable` will apply to these replays. Setting `defaultDestinationBehavior` to `imply` here will be interpreted as `enable` during a replay. 
+This setting will also also affect replays to new destinations. Only `disable` and `enable` will apply to these replays. Setting `defaultDestinationBehavior` to `imply` here will be interpreted as `enable` during a replay.
 
 ##### mapCustomPreferences
 
@@ -588,6 +597,13 @@ export default function() {
   )
 }
 ```
+
+##### cdnHost
+
+Type: `string`<br>
+Default: `cdn.segment.com`
+
+The CDN to fetch list of integrations from
 
 ### Utility functions
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "lodash-es": "^4.17.10",
     "nock": "^9.2.5",
     "preact": "^10.0.0",
-    "prettier": "1.18.2",
+    "prettier": "^1.19.1",
     "pretty-quick": "^1.11.1",
     "prismjs": "^1.17.1",
     "raw-loader": "^3.1.0",

--- a/src/__tests__/consent-manager-builder/fetch-destinations.test.ts
+++ b/src/__tests__/consent-manager-builder/fetch-destinations.test.ts
@@ -16,7 +16,7 @@ describe('fetchDestinations', () => {
         }
       ])
 
-    expect(await fetchDestinations(['123'])).toMatchObject([
+    expect(await fetchDestinations('cdn.segment.com', ['123'])).toMatchObject([
       {
         id: 'Amplitude',
         name: 'Amplitude'
@@ -38,7 +38,7 @@ describe('fetchDestinations', () => {
         }
       ])
 
-    expect(await fetchDestinations(['123'])).toMatchObject([
+    expect(await fetchDestinations('cdn.segment.com', ['123'])).toMatchObject([
       {
         id: 'Old Amplitude',
         name: 'New Amplitude'
@@ -71,7 +71,7 @@ describe('fetchDestinations', () => {
         }
       ])
 
-    expect(await fetchDestinations(['123', 'abc'])).toMatchObject([
+    expect(await fetchDestinations('cdn.segment.com', ['123', 'abc'])).toMatchObject([
       {
         id: 'Amplitude',
         name: 'Amplitude'

--- a/src/__tests__/consent-manager-builder/index.todo.js
+++ b/src/__tests__/consent-manager-builder/index.todo.js
@@ -324,6 +324,49 @@ describe('ConsentManagerBuilder', () => {
     )
   })
 
+  test('a different cdn is used when cdnHost is set', done => {
+    nock('https://foo.bar.com')
+      .get('/v1/projects/123/integrations')
+      .reply(200, [
+        {
+          name: 'Google Analytics',
+          creationName: 'Google Analytics'
+        },
+        {
+          name: 'Amplitude',
+          creationName: 'Amplitude'
+        }
+      ])
+      .get('/v1/projects/abc/integrations')
+      .reply(200, [
+        {
+          name: 'FullStory',
+          creationName: 'FullStory'
+        }
+      ])
+
+    shallow(
+      <ConsentManagerBuilder writeKey="123" otherWriteKeys={['abc']} cdnHost="foo.bar.com">
+        {({ destinations }) => {
+          expect(destinations).toMatchObject([
+            {
+              id: 'Amplitude',
+              name: 'Amplitude'
+            },
+            {
+              id: 'FullStory',
+              name: 'FullStory'
+            },
+            {
+              id: 'Google Analytics',
+              name: 'Google Analytics'
+            }
+          ])
+          done()
+        }}
+      </ConsentManagerBuilder>
+    )
+  })
   test.todo('loads analytics.js normally when consent isn՚t required')
   test.todo('still applies preferences when consent isn՚t required')
   test.todo('provides a setPreferences() function for setting the preferences')

--- a/src/consent-manager-builder/fetch-destinations.ts
+++ b/src/consent-manager-builder/fetch-destinations.ts
@@ -2,8 +2,11 @@ import fetch from 'isomorphic-fetch'
 import { flatten, sortedUniqBy, sortBy } from 'lodash'
 import { Destination } from '../types'
 
-async function fetchDestinationForWriteKey(writeKey: string): Promise<Destination[]> {
-  const res = await fetch(`https://cdn.segment.com/v1/projects/${writeKey}/integrations`)
+async function fetchDestinationForWriteKey(
+  cdnHost: string,
+  writeKey: string
+): Promise<Destination[]> {
+  const res = await fetch(`https://${cdnHost}/v1/projects/${writeKey}/integrations`)
 
   if (!res.ok) {
     throw new Error(
@@ -22,10 +25,13 @@ async function fetchDestinationForWriteKey(writeKey: string): Promise<Destinatio
   return destinations
 }
 
-export default async function fetchDestinations(writeKeys: string[]): Promise<Destination[]> {
+export default async function fetchDestinations(
+  cdnHost: string,
+  writeKeys: string[]
+): Promise<Destination[]> {
   const destinationsRequests: Promise<Destination[]>[] = []
   for (const writeKey of writeKeys) {
-    destinationsRequests.push(fetchDestinationForWriteKey(writeKey))
+    destinationsRequests.push(fetchDestinationForWriteKey(cdnHost, writeKey))
   }
 
   let destinations = flatten(await Promise.all(destinationsRequests))

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -72,6 +72,11 @@ interface Props {
    * A callback for dealing with errors in the Consent Manager
    */
   onError?: (err: Error) => void | Promise<void>
+
+  /**
+   * CDN to fetch list of integrations from
+   */
+  cdnHost?: string
 }
 
 interface RenderProps {
@@ -106,7 +111,8 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
     otherWriteKeys: [],
     onError: undefined,
     shouldRequireConsent: () => true,
-    initialPreferences: {}
+    initialPreferences: {},
+    cdnHost: 'cdn.segment.com'
   }
 
   state = {
@@ -172,14 +178,15 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       initialPreferences,
       mapCustomPreferences,
       defaultDestinationBehavior,
-      cookieDomain
+      cookieDomain,
+      cdnHost = ConsentManagerBuilder.defaultProps.cdnHost
     } = this.props
     // TODO: add option to run mapCustomPreferences on load so that the destination preferences automatically get updated
     let { destinationPreferences, customPreferences } = loadPreferences()
 
     const [isConsentRequired, destinations] = await Promise.all([
       shouldRequireConsent(),
-      fetchDestinations([writeKey, ...otherWriteKeys])
+      fetchDestinations(cdnHost, [writeKey, ...otherWriteKeys])
     ])
 
     const newDestinations = getNewDestinations(destinations, destinationPreferences || {})

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -74,31 +74,35 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
           havePreferencesChanged,
           workspaceAddedNewDestinations
         }) => {
-          return <Container
-            customCategories={customCategories}
-            destinations={destinations}
-            newDestinations={newDestinations}
-            preferences={preferences}
-            isConsentRequired={isConsentRequired}
-            setPreferences={setPreferences}
-            resetPreferences={resetPreferences}
-            saveConsent={saveConsent}
-            closeBehavior={this.props.closeBehavior}
-            implyConsentOnInteraction={implyConsentOnInteraction ?? ConsentManager.defaultProps.implyConsentOnInteraction}
-            bannerContent={bannerContent}
-            bannerSubContent={bannerSubContent}
-            bannerTextColor={bannerTextColor || ConsentManager.defaultProps.bannerTextColor}
-            bannerBackgroundColor={
-              bannerBackgroundColor || ConsentManager.defaultProps.bannerBackgroundColor
-            }
-            preferencesDialogTitle={preferencesDialogTitle}
-            preferencesDialogContent={preferencesDialogContent}
-            cancelDialogTitle={cancelDialogTitle}
-            cancelDialogContent={cancelDialogContent}
-            havePreferencesChanged={havePreferencesChanged}
-            defaultDestinationBehavior={defaultDestinationBehavior}
-            workspaceAddedNewDestinations={workspaceAddedNewDestinations}
-          />
+          return (
+            <Container
+              customCategories={customCategories}
+              destinations={destinations}
+              newDestinations={newDestinations}
+              preferences={preferences}
+              isConsentRequired={isConsentRequired}
+              setPreferences={setPreferences}
+              resetPreferences={resetPreferences}
+              saveConsent={saveConsent}
+              closeBehavior={this.props.closeBehavior}
+              implyConsentOnInteraction={
+                implyConsentOnInteraction ?? ConsentManager.defaultProps.implyConsentOnInteraction
+              }
+              bannerContent={bannerContent}
+              bannerSubContent={bannerSubContent}
+              bannerTextColor={bannerTextColor || ConsentManager.defaultProps.bannerTextColor}
+              bannerBackgroundColor={
+                bannerBackgroundColor || ConsentManager.defaultProps.bannerBackgroundColor
+              }
+              preferencesDialogTitle={preferencesDialogTitle}
+              preferencesDialogContent={preferencesDialogContent}
+              cancelDialogTitle={cancelDialogTitle}
+              cancelDialogContent={cancelDialogContent}
+              havePreferencesChanged={havePreferencesChanged}
+              defaultDestinationBehavior={defaultDestinationBehavior}
+              workspaceAddedNewDestinations={workspaceAddedNewDestinations}
+            />
+          )
         }}
       </ConsentManagerBuilder>
     )
@@ -138,7 +142,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
       }
 
       destinations.forEach(destination => {
-        // Mark custom categories 
+        // Mark custom categories
         Object.entries(customCategories).forEach(([categoryName, { integrations }]) => {
           const consentAlreadySetToFalse = destinationPreferences[destination.id] === false
           const shouldSetConsent = integrations.includes(destination.id)
@@ -165,12 +169,18 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
 
     for (const destination of destinations) {
       // Mark advertising destinations
-      if (ADVERTISING_CATEGORIES.find(c => c === destination.category) && destinationPreferences[destination.id] !== false) {
+      if (
+        ADVERTISING_CATEGORIES.find(c => c === destination.category) &&
+        destinationPreferences[destination.id] !== false
+      ) {
         destinationPreferences[destination.id] = customPrefs.advertising
       }
 
       // Mark function destinations
-      if (FUNCTIONAL_CATEGORIES.find(c => c === destination.category) && destinationPreferences[destination.id] !== false) {
+      if (
+        FUNCTIONAL_CATEGORIES.find(c => c === destination.category) &&
+        destinationPreferences[destination.id] !== false
+      ) {
         destinationPreferences[destination.id] = customPrefs.functional
       }
 

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -45,6 +45,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
       cancelDialogContent,
       customCategories,
       defaultDestinationBehavior,
+      cdnHost,
       onError
     } = this.props
 
@@ -59,6 +60,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
         mapCustomPreferences={this.handleMapCustomPreferences}
         customCategories={customCategories}
         defaultDestinationBehavior={defaultDestinationBehavior}
+        cdnHost={cdnHost}
       >
         {({
           destinations,

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,4 +94,5 @@ export interface ConsentManagerProps {
   initialPreferences?: CategoryPreferences
   customCategories?: CustomCategories
   defaultDestinationBehavior?: DefaultDestinationBehavior
+  cdnHost?: string
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12116,10 +12116,15 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@1.18.2, prettier@^1.16.4:
+prettier@^1.16.4:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
+
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 prettier@^1.5.3:
   version "1.12.1"


### PR DESCRIPTION
# Added configurable CDN host
This PR added a new prop `cdnHost` to `ConsentManager` and `ConsentManagerBuilder` with a default value of `cdn.segment.com` which is the same as the existing behavior. This allows users to use their own CDN instead of Segment's.

# Testing
Testing is done via unit tests and story book on my local dev environment.

**Default behavior is unchanged**
![image](https://user-images.githubusercontent.com/8295906/87084280-d5164e80-c1e2-11ea-8bd2-9aead8079492.png)

**React component: Setting cdnHost to another CDN**
![image](https://user-images.githubusercontent.com/8295906/87084505-363e2200-c1e3-11ea-99d6-958c7bf6dfaa.png)

**Standalone script: Setting cdnHost to another CDN**
![image](https://user-images.githubusercontent.com/8295906/87084797-a8166b80-c1e3-11ea-91b2-2dd3c9a7010d.png)
