### PR TITLE
Fix #55: missing TypeScript declarations in packaged output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /standalone/
 /build
 /storybook-static
+/types
 
 # IDE
 .vscode/

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
   "license": "MIT",
   "main": "commonjs/index.js",
   "module": "esm/index.js",
+  "types": "types/src/index.d.ts",
   "sideEffects": false,
   "files": [
     "commonjs",
     "esm",
-    "standalone"
+    "standalone",
+    "types"
   ],
   "scripts": {
     "test": "jest src/__tests__",
@@ -27,7 +29,7 @@
     "build-esm": "tsc --module es2015 --outDir esm --inlineSourceMap",
     "build-standalone": "webpack",
     "build": "concurrently --names 'commonjs,esm,standalone' 'yarn run build-commonjs' 'yarn run build-esm' 'yarn run build-standalone'",
-    "clean": "rm -rf commonjs esm standalone storybook-static",
+    "clean": "rm -rf commonjs esm standalone storybook-static types",
     "deploy-storybook": "storybook-to-ghpages",
     "standalone-hash": "shasum -b -a 256 standalone/consent-manager.js | xxd -r -p | base64",
     "build-storybook": "yarn build-standalone && build-storybook && cp -r ./standalone ./storybook-static/standalone",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,9 @@
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "declaration": true,
+    "declarationDir": "types"
   },
   "include": ["src"],
   "exclude": ["node_modules", "build"]


### PR DESCRIPTION
Hi there!

When installing this library in a TypeScript project, the compiler complains that declarations are missing ; while this library is written in TS (see #55).

This PR should address this issue by generating `.d.ts` files in dist and correctly declare it in `packages.json`.

Cheers!