### PR TITLE
🐛 Bug FIX: Updated "types" directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "main": "commonjs/index.js",
   "module": "esm/index.js",
-  "types": "types/src/index.d.ts",
+  "types": "types/index.d.ts",
   "sideEffects": false,
   "files": [
     "commonjs",


### PR DESCRIPTION
There is no `src` directory under the `types` directory, so the declarations were failing.
This PR points to the correct file.

Related to [#111](https://github.com/segmentio/consent-manager/pull/111).

kudos to my colleague @mrseanbaines who noticed the path was wrong.