### PR TITLE
Fix implyConsentOnInteraction behavior

### DIFF
--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -109,7 +109,10 @@ const Container: React.FC<ContainerProps> = props => {
       return
     }
 
-    props.saveConsent(undefined, false)
+    // Accept all consent on page interaction.
+    if (!isDialogOpen && props.implyConsentOnInteraction) {
+      onAcceptAll()
+    }
   }
 
   const showDialog = () => toggleDialog(true)


### PR DESCRIPTION
implyConsentOnInteraction was not working properly. It closed the banner and did not set the cookies.
The problem was fixed in this pr.

Solves issue #99 