### PR TITLE
Feature/preference dialog customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,25 +4,25 @@
 
 [StoryBook](https://segmentio.github.io/consent-manager/index.html)
 
-- [Segment Consent Manager](#segment-consent-manager) 
+- [Segment Consent Manager](#segment-consent-manager)
 - [Features](#features)
-- [Usage](#usage) 
-  - [Standalone Script](#standalone-script) 
-    - [Options](#options) 
-    - [Globals](#globals) 
-    - [Callback Function](#callback-function) 
-  - [ConsentManager](#consentmanager) 
-    - [Install](#install) 
+- [Usage](#usage)
+  - [Standalone Script](#standalone-script)
+    - [Options](#options)
+    - [Globals](#globals)
+    - [Callback Function](#callback-function)
+  - [ConsentManager](#consentmanager)
+    - [Install](#install)
     - [Example](#example)
-    - [Example in Next.js](#example-in-next.js)  
-    - [ConsentManager Props](#consentmanager-props) 
+    - [Example in Next.js](#example-in-next.js)
+    - [ConsentManager Props](#consentmanager-props)
   - [ConsentManagerBuilder](#consentmanagerbuilder)
-    - [Install](#install-1) 
-    - [Example](#example-1) 
-    - [ConsentManagerBuilder Props](#consentmanagerbuilder-props) 
-    - [ConsentManagerBuilder Render Props](#consentmanagerbuilder-render-props) 
+    - [Install](#install-1)
+    - [Example](#example-1)
+    - [ConsentManagerBuilder Props](#consentmanagerbuilder-props)
+    - [ConsentManagerBuilder Render Props](#consentmanagerbuilder-render-props)
   - [Utility functions](#utility-functions)
-- [Development](#development) 
+- [Development](#development)
 - [Publishing New Version](#publishing-new-version)
 - [License](#license)
 
@@ -285,47 +285,47 @@ export default function() {
 ```
 
 #### Example in Next.js
-In Next.js we do not have an html file where to inject the script. Here we will use the Script component to inject the snippet provided by Segment. 
+
+In Next.js we do not have an html file where to inject the script. Here we will use the Script component to inject the snippet provided by Segment.
 
 ```javascript
-import React from 'react';
-import Script from 'next/script';
-import { ConsentManager, openConsentManager } from '@segment/consent-manager';
+import React from 'react'
+import Script from 'next/script'
+import { ConsentManager, openConsentManager } from '@segment/consent-manager'
 
 export default function Home() {
   const bannerContent = (
     <span>
-      We use cookies (and other similar technologies) to collect data to improve
-      your experience on our site. By using our website, you’re agreeing to the
-      collection of data as described in our{' '}
-      <a href='/docs/legal/website-data-collection-policy/' target='_blank'>
+      We use cookies (and other similar technologies) to collect data to improve your experience on
+      our site. By using our website, you’re agreeing to the collection of data as described in our{' '}
+      <a href="/docs/legal/website-data-collection-policy/" target="_blank">
         Website Data Collection Policy
       </a>
       .
     </span>
-  );
-  const bannerSubContent = 'You can change your preferences at any time.';
-  const preferencesDialogTitle = 'Website Data Collection Preferences';
+  )
+  const bannerSubContent = 'You can change your preferences at any time.'
+  const preferencesDialogTitle = 'Website Data Collection Preferences'
   const preferencesDialogContent =
-    'We use data collected by cookies and JavaScript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site.';
-  const cancelDialogTitle = 'Are you sure you want to cancel?';
+    'We use data collected by cookies and JavaScript libraries to improve your browsing experience, analyze site traffic, deliver personalized advertisements, and increase the overall performance of our site.'
+  const cancelDialogTitle = 'Are you sure you want to cancel?'
   const cancelDialogContent =
-    'Your preferences have not been saved. By continuing to use our website, you՚re agreeing to our Website Data Collection Policy.';
+    'Your preferences have not been saved. By continuing to use our website, you՚re agreeing to our Website Data Collection Policy.'
 
   return (
     <div>
       <Script
-        id='show-banner'
+        id="show-banner"
         dangerouslySetInnerHTML={{
           __html: `!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};;analytics.SNIPPET_VERSION="4.13.2";
           analytics.page();
-          }}();`,
+          }}();`
         }}
       />
 
       <main>
         <ConsentManager
-          writeKey='5V8KznnIFIDh1ejQLbmX7ikfSRa6r8bF'
+          writeKey="5V8KznnIFIDh1ejQLbmX7ikfSRa6r8bF"
           bannerContent={bannerContent}
           bannerSubContent={bannerSubContent}
           preferencesDialogTitle={preferencesDialogTitle}
@@ -335,12 +335,12 @@ export default function Home() {
           bannerActionsBlock={true}
         />
 
-        <button type='button' onClick={openConsentManager}>
+        <button type="button" onClick={openConsentManager}>
           Website Data Collection Preferences
         </button>
       </main>
     </div>
-  );
+  )
 }
 ```
 
@@ -367,6 +367,7 @@ loading the out of the box Consent Manager. In [this demo](https://codepen.io/sa
 - [cancelDialogTitle](#canceldialogtitle)
 - [cancelDialogContent](#canceldialogcontent)
 - [customCategories](#customcategories)
+- [preferencesDialogTemplate](#preferencesdialogtemplate)
 
 <!-- /TOC -->
 
@@ -562,6 +563,73 @@ const customCategories = {
 ```
 
 The values for `integrations` should be an integration's creationName (`integration.creationName`). You can find examples of that by going to `https://cdn.segment.com/v1/projects/<writeKey>/integrations`
+
+##### preferencesDialogTemplate
+
+**Type**: `PropTypes.object`
+**Default**:
+
+```javascript
+{
+  headings: {
+    allowValue: 'Allow',
+    categoryValue: 'Category',
+    purposeValue: 'Purpose',
+    toolsValue: 'Tools'
+  },
+  checkboxes: {
+    noValue: 'No',
+    yesValue: 'Yes'
+  },
+  actionButtons: {
+    cancelValue: 'Cancel',
+    saveValue: 'Save'
+  },
+  cancelDialogButtons: {
+    cancelValue: 'Yes, Cancel',
+    backValue: 'Go Back'
+  },
+  categories: [
+    {
+      key: 'functional',
+      name: 'Functional',
+      description:
+        'To monitor the performance of our site and to enhance your browsing experience.',
+      example: 'For example, these tools enable you to communicate with us via live chat.'
+    },
+    {
+      key: 'marketing',
+      name: 'Marketing and Analytics',
+      description:
+        'To understand user behavior in order to provide you with a more relevant browsing experience or personalize the content on our site.',
+      example:
+        'For example, we collect information about which pages you visit to help us present more relevant information.'
+    },
+    {
+      key: 'advertising',
+      name: 'Advertising',
+      description:
+        'To personalize and measure the effectiveness of advertising on our site and other websites.',
+      example:
+        'For example, we may serve you a personalized ad based on the pages you visit on our site.'
+    },
+    {
+      key: 'essential',
+      name: 'Essential',
+      description: 'We use browser cookies that are necessary for the site to work as intended.',
+      example:
+        'For example, we store your website data collection preferences so we can honor them if you return to our site. You can disable these cookies in your browser settings but if you do the site may not work as intended.'
+    }
+  ]
+}
+```
+
+An object that represents the text fields of the preferences dialog and allows customizing them.
+We recommend copying the default object and changing the fields as necessary.
+
+_Note: All fields are optional. If they are not included in the template (object) the default fields will be used._
+
+_Note 2: For categories, you need to provide the key in order to map all the values properly._
 
 ### ConsentManagerBuilder
 

--- a/src/consent-manager/cancel-dialog.tsx
+++ b/src/consent-manager/cancel-dialog.tsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react'
 import Dialog from './dialog'
 import { DefaultButton, RedButton } from './buttons'
+import { PreferenceDialogTemplate } from '../types'
 
 interface Props {
   innerRef: (node: HTMLElement) => void
@@ -8,20 +9,23 @@ interface Props {
   onConfirm: () => void
   title: React.ReactNode
   content: React.ReactNode
+  preferencesDialogTemplate?: PreferenceDialogTemplate
 }
 
 export default class CancelDialog extends PureComponent<Props> {
   static displayName = 'CancelDialog'
 
   render() {
-    const { innerRef, onBack, title, content } = this.props
+    const { innerRef, onBack, title, content, preferencesDialogTemplate } = this.props
 
     const buttons = (
       <div>
         <DefaultButton type="button" onClick={onBack}>
-          Go Back
+          {preferencesDialogTemplate?.cancelDialogButtons.backValue}
         </DefaultButton>
-        <RedButton type="submit">Yes, Cancel</RedButton>
+        <RedButton type="submit">
+          {preferencesDialogTemplate?.cancelDialogButtons.cancelValue}
+        </RedButton>
       </div>
     )
 

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -52,6 +52,7 @@ interface ContainerProps {
   cancelDialogContent: React.ReactNode
   workspaceAddedNewDestinations?: boolean
   defaultDestinationBehavior?: DefaultDestinationBehavior
+  preferencesDialogTemplate?: any
 }
 
 function normalizeDestinations(destinations: Destination[]) {
@@ -238,6 +239,7 @@ const Container: React.FC<ContainerProps> = props => {
           functional={props.preferences.functional}
           title={props.preferencesDialogTitle}
           content={props.preferencesDialogContent}
+          preferencesDialogTemplate={props.preferencesDialogTemplate}
         />
       )}
 

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -251,6 +251,7 @@ const Container: React.FC<ContainerProps> = props => {
           onConfirm={handleCancelConfirm}
           title={props.cancelDialogTitle}
           content={props.cancelDialogContent}
+          preferencesDialogTemplate={props.preferencesDialogTemplate}
         />
       )}
     </div>

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -9,7 +9,8 @@ import {
   CategoryPreferences,
   CustomCategories,
   DefaultDestinationBehavior,
-  ActionsBlockProps
+  ActionsBlockProps,
+  PreferenceDialogTemplate
 } from '../types'
 
 const emitter = new EventEmitter()
@@ -52,7 +53,7 @@ interface ContainerProps {
   cancelDialogContent: React.ReactNode
   workspaceAddedNewDestinations?: boolean
   defaultDestinationBehavior?: DefaultDestinationBehavior
-  preferencesDialogTemplate?: any
+  preferencesDialogTemplate?: PreferenceDialogTemplate
 }
 
 function normalizeDestinations(destinations: Destination[]) {

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -30,6 +30,10 @@ const defaultPreferencesDialogTemplate: PreferenceDialogTemplate = {
     cancelValue: 'Cancel',
     saveValue: 'Save'
   },
+  cancelDialogButtons: {
+    cancelValue: 'Yes, Cancel',
+    backValue: 'Go Back'
+  },
   categories: [
     {
       key: 'functional',
@@ -198,6 +202,10 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
       ...defaultPreferencesDialogTemplate.actionButtons,
       ...newProps.actionButtons
     }
+    const cancelDialogButtonsMerge = {
+      ...defaultPreferencesDialogTemplate.cancelDialogButtons,
+      ...newProps.cancelDialogButtons
+    }
     const categoriesMerge = defaultPreferencesDialogTemplate?.categories.map(category => ({
       ...category,
       ...newProps?.categories?.find(c => c.key === category.key)
@@ -206,6 +214,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
       headings: headingsMerge,
       checkboxes: checkboxesMerge,
       actionButtons: actionButtonsMerge,
+      cancelDialogButtons: cancelDialogButtonsMerge,
       categories: categoriesMerge
     }
   }

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -2,7 +2,13 @@ import React, { PureComponent } from 'react'
 import ConsentManagerBuilder from '../consent-manager-builder'
 import Container from './container'
 import { ADVERTISING_CATEGORIES, FUNCTIONAL_CATEGORIES } from './categories'
-import { CategoryPreferences, Destination, ConsentManagerProps } from '../types'
+import {
+  CategoryPreferences,
+  Destination,
+  ConsentManagerProps,
+  PreferenceDialogTemplate,
+  PreferencesCategoriesKeys
+} from '../types'
 
 const zeroValuePreferences: CategoryPreferences = {
   marketingAndAnalytics: null,
@@ -10,18 +16,25 @@ const zeroValuePreferences: CategoryPreferences = {
   functional: null
 }
 
-const defaultPreferencesDialogTemplate = {
-  headings: ['Allow', 'Category', 'Purpose', 'Tools'],
+const defaultPreferencesDialogTemplate: PreferenceDialogTemplate = {
+  headings: {
+    allowValue: 'Allow',
+    categoryValue: 'Category',
+    purposeValue: 'Purpose',
+    toolsValue: 'Tools'
+  },
   checkboxes: ['Yes', 'No'],
   actionButtons: ['Cancel', 'Save'],
   categories: [
     {
+      key: PreferencesCategoriesKeys.FUNCTIONAL,
       name: 'Functional',
       description:
         'To monitor the performance of our site and to enhance your browsing experience.',
       example: 'For example, these tools enable you to communicate with us via live chat.'
     },
     {
+      key: PreferencesCategoriesKeys.MARKETING,
       name: 'Marketing and Analytics',
       description:
         'To understand user behavior in order to provide you with a more relevant browsing experience or personalize the content on our site.',
@@ -29,6 +42,7 @@ const defaultPreferencesDialogTemplate = {
         'For example, we collect information about which pages you visit to help us present more relevant information.'
     },
     {
+      key: PreferencesCategoriesKeys.ADVERTISING,
       name: 'Advertising',
       description:
         'To personalize and measure the effectiveness of advertising on our site and other websites.',
@@ -36,6 +50,7 @@ const defaultPreferencesDialogTemplate = {
         'For example, we may serve you a personalized ad based on the pages you visit on our site.'
     },
     {
+      key: PreferencesCategoriesKeys.ESSENTIAL,
       name: 'Essential',
       description: 'We use browser cookies that are necessary for the site to work as intended.',
       example:
@@ -43,7 +58,6 @@ const defaultPreferencesDialogTemplate = {
     }
   ]
 }
-
 export default class ConsentManager extends PureComponent<ConsentManagerProps, {}> {
   static displayName = 'ConsentManager'
 
@@ -152,13 +166,43 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
               defaultDestinationBehavior={defaultDestinationBehavior}
               workspaceAddedNewDestinations={workspaceAddedNewDestinations}
               preferencesDialogTemplate={
-                preferencesDialogTemplate || ConsentManager.defaultProps.preferencesDialogTemplate
+                preferencesDialogTemplate
+                  ? this.mergeTemplates(preferencesDialogTemplate, defaultPreferencesDialogTemplate)
+                  : ConsentManager.defaultProps.preferencesDialogTemplate
               }
             />
           )
         }}
       </ConsentManagerBuilder>
     )
+  }
+
+  mergeTemplates = (
+    newProps: PreferenceDialogTemplate,
+    defaultPreferencesDialogTemplate: PreferenceDialogTemplate
+  ): PreferenceDialogTemplate => {
+    const headingsMerge = {
+      ...defaultPreferencesDialogTemplate.headings,
+      ...newProps.headings
+    }
+    const checkboxesMerge = {
+      ...defaultPreferencesDialogTemplate.checkboxes,
+      ...newProps.checkboxes
+    }
+    const actionButtonsMerge = {
+      ...defaultPreferencesDialogTemplate.actionButtons,
+      ...newProps.actionButtons
+    }
+    const categoriesMerge = defaultPreferencesDialogTemplate?.categories.map(category => ({
+      ...category,
+      ...newProps?.categories?.find(c => c.key === category.key)
+    }))
+    return {
+      headings: headingsMerge,
+      checkboxes: checkboxesMerge,
+      actionButtons: actionButtonsMerge,
+      categories: categoriesMerge
+    }
   }
 
   getInitialPreferences = () => {

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -206,7 +206,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
       ...defaultPreferencesDialogTemplate.cancelDialogButtons,
       ...newProps.cancelDialogButtons
     }
-    const categoriesMerge = defaultPreferencesDialogTemplate?.categories.map(category => ({
+    const categoriesMerge = defaultPreferencesDialogTemplate?.categories!.map(category => ({
       ...category,
       ...newProps?.categories?.find(c => c.key === category.key)
     }))

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -6,8 +6,7 @@ import {
   CategoryPreferences,
   Destination,
   ConsentManagerProps,
-  PreferenceDialogTemplate,
-  PreferencesCategoriesKeys
+  PreferenceDialogTemplate
 } from '../types'
 
 const zeroValuePreferences: CategoryPreferences = {
@@ -23,18 +22,24 @@ const defaultPreferencesDialogTemplate: PreferenceDialogTemplate = {
     purposeValue: 'Purpose',
     toolsValue: 'Tools'
   },
-  checkboxes: ['Yes', 'No'],
-  actionButtons: ['Cancel', 'Save'],
+  checkboxes: {
+    noValue: 'No',
+    yesValue: 'Yes'
+  },
+  actionButtons: {
+    cancelValue: 'Cancel',
+    saveValue: 'Save'
+  },
   categories: [
     {
-      key: PreferencesCategoriesKeys.FUNCTIONAL,
+      key: 'functional',
       name: 'Functional',
       description:
         'To monitor the performance of our site and to enhance your browsing experience.',
       example: 'For example, these tools enable you to communicate with us via live chat.'
     },
     {
-      key: PreferencesCategoriesKeys.MARKETING,
+      key: 'marketing',
       name: 'Marketing and Analytics',
       description:
         'To understand user behavior in order to provide you with a more relevant browsing experience or personalize the content on our site.',
@@ -42,7 +47,7 @@ const defaultPreferencesDialogTemplate: PreferenceDialogTemplate = {
         'For example, we collect information about which pages you visit to help us present more relevant information.'
     },
     {
-      key: PreferencesCategoriesKeys.ADVERTISING,
+      key: 'advertising',
       name: 'Advertising',
       description:
         'To personalize and measure the effectiveness of advertising on our site and other websites.',
@@ -50,7 +55,7 @@ const defaultPreferencesDialogTemplate: PreferenceDialogTemplate = {
         'For example, we may serve you a personalized ad based on the pages you visit on our site.'
     },
     {
-      key: PreferencesCategoriesKeys.ESSENTIAL,
+      key: 'essential',
       name: 'Essential',
       description: 'We use browser cookies that are necessary for the site to work as intended.',
       example:

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -10,6 +10,40 @@ const zeroValuePreferences: CategoryPreferences = {
   functional: null
 }
 
+const defaultPreferencesDialogTemplate = {
+  headings: ['Allow', 'Category', 'Purpose', 'Tools'],
+  checkboxes: ['Yes', 'No'],
+  actionButtons: ['Cancel', 'Save'],
+  categories: [
+    {
+      name: 'Functional',
+      description:
+        'To monitor the performance of our site and to enhance your browsing experience.',
+      example: 'For example, these tools enable you to communicate with us via live chat.'
+    },
+    {
+      name: 'Marketing and Analytics',
+      description:
+        'To understand user behavior in order to provide you with a more relevant browsing experience or personalize the content on our site.',
+      example:
+        'For example, we collect information about which pages you visit to help us present more relevant information.'
+    },
+    {
+      name: 'Advertising',
+      description:
+        'To personalize and measure the effectiveness of advertising on our site and other websites.',
+      example:
+        'For example, we may serve you a personalized ad based on the pages you visit on our site.'
+    },
+    {
+      name: 'Essential',
+      description: 'We use browser cookies that are necessary for the site to work as intended.',
+      example:
+        'For example, we store your website data collection preferences so we can honor them if you return to our site. You can disable these cookies in your browser settings but if you do the site may not work as intended.'
+    }
+  ]
+}
+
 export default class ConsentManager extends PureComponent<ConsentManagerProps, {}> {
   static displayName = 'ConsentManager'
 
@@ -29,7 +63,8 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
     bannerBackgroundColor: '#1f4160',
     preferencesDialogTitle: 'Website Data Collection Preferences',
     cancelDialogTitle: 'Are you sure you want to cancel?',
-    defaultDestinationBehavior: 'disable'
+    defaultDestinationBehavior: 'disable',
+    preferencesDialogTemplate: defaultPreferencesDialogTemplate
   }
 
   render() {
@@ -55,6 +90,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
       customCategories,
       defaultDestinationBehavior,
       cdnHost,
+      preferencesDialogTemplate,
       onError
     } = this.props
 
@@ -115,6 +151,9 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
               havePreferencesChanged={havePreferencesChanged}
               defaultDestinationBehavior={defaultDestinationBehavior}
               workspaceAddedNewDestinations={workspaceAddedNewDestinations}
+              preferencesDialogTemplate={
+                preferencesDialogTemplate || ConsentManager.defaultProps.preferencesDialogTemplate
+              }
             />
           )
         }}

--- a/src/consent-manager/preference-dialog.tsx
+++ b/src/consent-manager/preference-dialog.tsx
@@ -72,6 +72,7 @@ interface PreferenceDialogProps {
   preferences: CategoryPreferences
   title: React.ReactNode
   content: React.ReactNode
+  preferencesDialogTemplate?: any
 }
 
 export default class PreferenceDialog extends PureComponent<PreferenceDialogProps, {}> {
@@ -97,16 +98,21 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
       destinations,
       title,
       content,
-      preferences
+      preferences,
+      preferencesDialogTemplate
     } = this.props
+
+    const { headings, checkboxes, actionButtons, categories } = preferencesDialogTemplate
+
     const buttons = (
       <div>
         <DefaultButton type="button" onClick={onCancel}>
-          Cancel
+          {actionButtons[0]}
         </DefaultButton>
-        <GreenButton type="submit">Save</GreenButton>
+        <GreenButton type="submit">{actionButtons[1]}</GreenButton>
       </div>
     )
+
     return (
       <Dialog
         innerRef={innerRef}
@@ -121,11 +127,11 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
           <Table>
             <thead>
               <Row>
-                <ColumnHeading scope="col">Allow</ColumnHeading>
-                <ColumnHeading scope="col">Category</ColumnHeading>
-                <ColumnHeading scope="col">Purpose</ColumnHeading>
+                <ColumnHeading scope="col">{headings[0]}</ColumnHeading>
+                <ColumnHeading scope="col">{headings[1]}</ColumnHeading>
+                <ColumnHeading scope="col">{headings[2]}</ColumnHeading>
                 <ColumnHeading scope="col" className={hideOnMobile}>
-                  Tools
+                  {headings[3]}
                 </ColumnHeading>
               </Row>
             </thead>
@@ -145,7 +151,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Allow functional tracking"
                           required
                         />{' '}
-                        Yes
+                        {checkboxes[0]}
                       </label>
                       <label>
                         <input
@@ -157,18 +163,13 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Disallow functional tracking"
                           required
                         />{' '}
-                        No
+                        {checkboxes[1]}
                       </label>
                     </InputCell>
-                    <RowHeading scope="row">Functional</RowHeading>
+                    <RowHeading scope="row">{categories[0].name}</RowHeading>
                     <td>
-                      <p>
-                        To monitor the performance of our site and to enhance your browsing
-                        experience.
-                      </p>
-                      <p className={hideOnMobile}>
-                        For example, these tools enable you to communicate with us via live chat.
-                      </p>
+                      <p>{categories[0].description}</p>
+                      <p className={hideOnMobile}>{categories[0].example}</p>
                     </td>
                     <td className={hideOnMobile}>
                       {functionalDestinations.map(d => d.name).join(', ')}
@@ -187,7 +188,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Allow marketing and analytics tracking"
                           required
                         />{' '}
-                        Yes
+                        {checkboxes[0]}
                       </label>
                       <label>
                         <input
@@ -199,19 +200,13 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Disallow marketing and analytics tracking"
                           required
                         />{' '}
-                        No
+                        {checkboxes[1]}
                       </label>
                     </InputCell>
-                    <RowHeading scope="row">Marketing and Analytics</RowHeading>
+                    <RowHeading scope="row">{categories[1].name}</RowHeading>
                     <td>
-                      <p>
-                        To understand user behavior in order to provide you with a more relevant
-                        browsing experience or personalize the content on our site.
-                      </p>
-                      <p className={hideOnMobile}>
-                        For example, we collect information about which pages you visit to help us
-                        present more relevant information.
-                      </p>
+                      <p>{categories[1].description}</p>
+                      <p className={hideOnMobile}>{categories[1].example}</p>
                     </td>
                     <td className={hideOnMobile}>
                       {marketingDestinations.map(d => d.name).join(', ')}
@@ -230,7 +225,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Allow advertising tracking"
                           required
                         />{' '}
-                        Yes
+                        {checkboxes[0]}
                       </label>
                       <label>
                         <input
@@ -242,19 +237,13 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Disallow advertising tracking"
                           required
                         />{' '}
-                        No
+                        {checkboxes[1]}
                       </label>
                     </InputCell>
-                    <RowHeading scope="row">Advertising</RowHeading>
+                    <RowHeading scope="row">{categories[2].name}</RowHeading>
                     <td>
-                      <p>
-                        To personalize and measure the effectiveness of advertising on our site and
-                        other websites.
-                      </p>
-                      <p className={hideOnMobile}>
-                        For example, we may serve you a personalized ad based on the pages you visit
-                        on our site.
-                      </p>
+                      <p>{categories[2].description}</p>
+                      <p className={hideOnMobile}>{categories[2].example}</p>
                     </td>
                     <td className={hideOnMobile}>
                       {advertisingDestinations.map(d => d.name).join(', ')}
@@ -278,7 +267,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                             aria-label={`Allow "${categoryName}" tracking`}
                             required
                           />{' '}
-                          Yes
+                          {checkboxes[0]}
                         </label>
                         <label>
                           <input
@@ -290,7 +279,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                             aria-label={`Disallow "${categoryName}" tracking`}
                             required
                           />{' '}
-                          No
+                          {checkboxes[1]}
                         </label>
                       </InputCell>
                       <RowHeading scope="row">{categoryName}</RowHeading>
@@ -309,14 +298,10 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
 
               <Row>
                 <td>N/A</td>
-                <RowHeading scope="row">Essential</RowHeading>
+                <RowHeading scope="row">{categories[3].name}</RowHeading>
                 <td>
-                  <p>We use browser cookies that are necessary for the site to work as intended.</p>
-                  <p>
-                    For example, we store your website data collection preferences so we can honor
-                    them if you return to our site. You can disable these cookies in your browser
-                    settings but if you do the site may not work as intended.
-                  </p>
+                  <p>{categories[3].description}</p>
+                  <p>{categories[3].example}</p>
                 </td>
                 <td className={hideOnMobile} />
               </Row>

--- a/src/consent-manager/preference-dialog.tsx
+++ b/src/consent-manager/preference-dialog.tsx
@@ -2,7 +2,13 @@ import React, { PureComponent } from 'react'
 import styled, { css } from 'react-emotion'
 import Dialog from './dialog'
 import { DefaultButton, GreenButton } from './buttons'
-import { Destination, CustomCategories, CategoryPreferences } from '../types'
+import {
+  Destination,
+  CustomCategories,
+  CategoryPreferences,
+  PreferenceDialogTemplate,
+  PreferencesCategoriesKeys
+} from '../types'
 
 const hideOnMobile = css`
   @media (max-width: 600px) {
@@ -72,7 +78,7 @@ interface PreferenceDialogProps {
   preferences: CategoryPreferences
   title: React.ReactNode
   content: React.ReactNode
-  preferencesDialogTemplate?: any
+  preferencesDialogTemplate?: PreferenceDialogTemplate
 }
 
 export default class PreferenceDialog extends PureComponent<PreferenceDialogProps, {}> {
@@ -102,14 +108,27 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
       preferencesDialogTemplate
     } = this.props
 
-    const { headings, checkboxes, actionButtons, categories } = preferencesDialogTemplate
+    // const { headings, checkboxes, actionButtons, categories } = preferencesDialogTemplate
+
+    const functionalInfo = preferencesDialogTemplate?.categories.find(
+      c => c.key === PreferencesCategoriesKeys.FUNCTIONAL
+    )
+    const marketingInfo = preferencesDialogTemplate?.categories.find(
+      c => c.key === PreferencesCategoriesKeys.MARKETING
+    )
+    const advertisingInfo = preferencesDialogTemplate?.categories.find(
+      c => c.key === PreferencesCategoriesKeys.ADVERTISING
+    )
+    const essentialInfo = preferencesDialogTemplate?.categories.find(
+      c => c.key === PreferencesCategoriesKeys.ESSENTIAL
+    )
 
     const buttons = (
       <div>
         <DefaultButton type="button" onClick={onCancel}>
-          {actionButtons[0]}
+          {preferencesDialogTemplate?.actionButtons[0]}
         </DefaultButton>
-        <GreenButton type="submit">{actionButtons[1]}</GreenButton>
+        <GreenButton type="submit">{preferencesDialogTemplate?.actionButtons[1]}</GreenButton>
       </div>
     )
 
@@ -127,11 +146,17 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
           <Table>
             <thead>
               <Row>
-                <ColumnHeading scope="col">{headings[0]}</ColumnHeading>
-                <ColumnHeading scope="col">{headings[1]}</ColumnHeading>
-                <ColumnHeading scope="col">{headings[2]}</ColumnHeading>
+                <ColumnHeading scope="col">
+                  {preferencesDialogTemplate?.headings.allowValue}
+                </ColumnHeading>
+                <ColumnHeading scope="col">
+                  {preferencesDialogTemplate?.headings.categoryValue}
+                </ColumnHeading>
+                <ColumnHeading scope="col">
+                  {preferencesDialogTemplate?.headings.purposeValue}
+                </ColumnHeading>
                 <ColumnHeading scope="col" className={hideOnMobile}>
-                  {headings[3]}
+                  {preferencesDialogTemplate?.headings.toolsValue}
                 </ColumnHeading>
               </Row>
             </thead>
@@ -151,7 +176,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Allow functional tracking"
                           required
                         />{' '}
-                        {checkboxes[0]}
+                        {preferencesDialogTemplate?.checkboxes[0]}
                       </label>
                       <label>
                         <input
@@ -163,13 +188,13 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Disallow functional tracking"
                           required
                         />{' '}
-                        {checkboxes[1]}
+                        {preferencesDialogTemplate?.checkboxes[1]}
                       </label>
                     </InputCell>
-                    <RowHeading scope="row">{categories[0].name}</RowHeading>
+                    <RowHeading scope="row">{functionalInfo?.name}</RowHeading>
                     <td>
-                      <p>{categories[0].description}</p>
-                      <p className={hideOnMobile}>{categories[0].example}</p>
+                      <p>{functionalInfo?.description}</p>
+                      <p className={hideOnMobile}>{functionalInfo?.example}</p>
                     </td>
                     <td className={hideOnMobile}>
                       {functionalDestinations.map(d => d.name).join(', ')}
@@ -188,7 +213,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Allow marketing and analytics tracking"
                           required
                         />{' '}
-                        {checkboxes[0]}
+                        {preferencesDialogTemplate?.checkboxes[0]}
                       </label>
                       <label>
                         <input
@@ -200,13 +225,13 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Disallow marketing and analytics tracking"
                           required
                         />{' '}
-                        {checkboxes[1]}
+                        {preferencesDialogTemplate?.checkboxes[1]}
                       </label>
                     </InputCell>
-                    <RowHeading scope="row">{categories[1].name}</RowHeading>
+                    <RowHeading scope="row">{marketingInfo?.name}</RowHeading>
                     <td>
-                      <p>{categories[1].description}</p>
-                      <p className={hideOnMobile}>{categories[1].example}</p>
+                      <p>{marketingInfo?.description}</p>
+                      <p className={hideOnMobile}>{marketingInfo?.example}</p>
                     </td>
                     <td className={hideOnMobile}>
                       {marketingDestinations.map(d => d.name).join(', ')}
@@ -225,7 +250,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Allow advertising tracking"
                           required
                         />{' '}
-                        {checkboxes[0]}
+                        {preferencesDialogTemplate?.checkboxes[0]}
                       </label>
                       <label>
                         <input
@@ -237,13 +262,13 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Disallow advertising tracking"
                           required
                         />{' '}
-                        {checkboxes[1]}
+                        {preferencesDialogTemplate?.checkboxes[1]}
                       </label>
                     </InputCell>
-                    <RowHeading scope="row">{categories[2].name}</RowHeading>
+                    <RowHeading scope="row">{advertisingInfo?.name}</RowHeading>
                     <td>
-                      <p>{categories[2].description}</p>
-                      <p className={hideOnMobile}>{categories[2].example}</p>
+                      <p>{advertisingInfo?.description}</p>
+                      <p className={hideOnMobile}>{advertisingInfo?.example}</p>
                     </td>
                     <td className={hideOnMobile}>
                       {advertisingDestinations.map(d => d.name).join(', ')}
@@ -267,7 +292,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                             aria-label={`Allow "${categoryName}" tracking`}
                             required
                           />{' '}
-                          {checkboxes[0]}
+                          {preferencesDialogTemplate?.checkboxes[0]}
                         </label>
                         <label>
                           <input
@@ -279,7 +304,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                             aria-label={`Disallow "${categoryName}" tracking`}
                             required
                           />{' '}
-                          {checkboxes[1]}
+                          {preferencesDialogTemplate?.checkboxes[1]}
                         </label>
                       </InputCell>
                       <RowHeading scope="row">{categoryName}</RowHeading>
@@ -298,10 +323,10 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
 
               <Row>
                 <td>N/A</td>
-                <RowHeading scope="row">{categories[3].name}</RowHeading>
+                <RowHeading scope="row">{essentialInfo?.name}</RowHeading>
                 <td>
-                  <p>{categories[3].description}</p>
-                  <p>{categories[3].example}</p>
+                  <p>{essentialInfo?.description}</p>
+                  <p>{essentialInfo?.example}</p>
                 </td>
                 <td className={hideOnMobile} />
               </Row>

--- a/src/consent-manager/preference-dialog.tsx
+++ b/src/consent-manager/preference-dialog.tsx
@@ -109,17 +109,19 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
 
     const { headings, checkboxes, actionButtons } = preferencesDialogTemplate!
 
-    const functionalInfo = preferencesDialogTemplate?.categories.find(c => c.key === 'functional')
-    const marketingInfo = preferencesDialogTemplate?.categories.find(c => c.key === 'marketing')
-    const advertisingInfo = preferencesDialogTemplate?.categories.find(c => c.key === 'advertising')
-    const essentialInfo = preferencesDialogTemplate?.categories.find(c => c.key === 'essential')
+    const functionalInfo = preferencesDialogTemplate?.categories!.find(c => c.key === 'functional')
+    const marketingInfo = preferencesDialogTemplate?.categories!.find(c => c.key === 'marketing')
+    const advertisingInfo = preferencesDialogTemplate?.categories!.find(
+      c => c.key === 'advertising'
+    )
+    const essentialInfo = preferencesDialogTemplate?.categories!.find(c => c.key === 'essential')
 
     const buttons = (
       <div>
         <DefaultButton type="button" onClick={onCancel}>
-          {actionButtons.cancelValue}
+          {actionButtons!.cancelValue}
         </DefaultButton>
-        <GreenButton type="submit">{actionButtons.saveValue}</GreenButton>
+        <GreenButton type="submit">{actionButtons!.saveValue}</GreenButton>
       </div>
     )
 
@@ -137,11 +139,11 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
           <Table>
             <thead>
               <Row>
-                <ColumnHeading scope="col">{headings.allowValue}</ColumnHeading>
-                <ColumnHeading scope="col">{headings.categoryValue}</ColumnHeading>
-                <ColumnHeading scope="col">{headings.purposeValue}</ColumnHeading>
+                <ColumnHeading scope="col">{headings!.allowValue}</ColumnHeading>
+                <ColumnHeading scope="col">{headings!.categoryValue}</ColumnHeading>
+                <ColumnHeading scope="col">{headings!.purposeValue}</ColumnHeading>
                 <ColumnHeading scope="col" className={hideOnMobile}>
-                  {headings.toolsValue}
+                  {headings!.toolsValue}
                 </ColumnHeading>
               </Row>
             </thead>
@@ -161,7 +163,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Allow functional tracking"
                           required
                         />{' '}
-                        {checkboxes.yesValue}
+                        {checkboxes!.yesValue}
                       </label>
                       <label>
                         <input
@@ -173,7 +175,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Disallow functional tracking"
                           required
                         />{' '}
-                        {checkboxes.noValue}
+                        {checkboxes!.noValue}
                       </label>
                     </InputCell>
                     <RowHeading scope="row">{functionalInfo?.name}</RowHeading>
@@ -198,7 +200,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Allow marketing and analytics tracking"
                           required
                         />{' '}
-                        {checkboxes.yesValue}
+                        {checkboxes!.yesValue}
                       </label>
                       <label>
                         <input
@@ -210,7 +212,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Disallow marketing and analytics tracking"
                           required
                         />{' '}
-                        {checkboxes.noValue}
+                        {checkboxes!.noValue}
                       </label>
                     </InputCell>
                     <RowHeading scope="row">{marketingInfo?.name}</RowHeading>
@@ -235,7 +237,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Allow advertising tracking"
                           required
                         />{' '}
-                        {checkboxes.yesValue}
+                        {checkboxes!.yesValue}
                       </label>
                       <label>
                         <input
@@ -247,7 +249,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Disallow advertising tracking"
                           required
                         />{' '}
-                        {checkboxes.noValue}
+                        {checkboxes!.noValue}
                       </label>
                     </InputCell>
                     <RowHeading scope="row">{advertisingInfo?.name}</RowHeading>
@@ -277,7 +279,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                             aria-label={`Allow "${categoryName}" tracking`}
                             required
                           />{' '}
-                          {checkboxes.yesValue}
+                          {checkboxes!.yesValue}
                         </label>
                         <label>
                           <input
@@ -289,7 +291,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                             aria-label={`Disallow "${categoryName}" tracking`}
                             required
                           />{' '}
-                          {checkboxes.noValue}
+                          {checkboxes!.noValue}
                         </label>
                       </InputCell>
                       <RowHeading scope="row">{categoryName}</RowHeading>

--- a/src/consent-manager/preference-dialog.tsx
+++ b/src/consent-manager/preference-dialog.tsx
@@ -6,8 +6,7 @@ import {
   Destination,
   CustomCategories,
   CategoryPreferences,
-  PreferenceDialogTemplate,
-  PreferencesCategoriesKeys
+  PreferenceDialogTemplate
 } from '../types'
 
 const hideOnMobile = css`
@@ -108,27 +107,19 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
       preferencesDialogTemplate
     } = this.props
 
-    // const { headings, checkboxes, actionButtons, categories } = preferencesDialogTemplate
+    const { headings, checkboxes, actionButtons } = preferencesDialogTemplate!
 
-    const functionalInfo = preferencesDialogTemplate?.categories.find(
-      c => c.key === PreferencesCategoriesKeys.FUNCTIONAL
-    )
-    const marketingInfo = preferencesDialogTemplate?.categories.find(
-      c => c.key === PreferencesCategoriesKeys.MARKETING
-    )
-    const advertisingInfo = preferencesDialogTemplate?.categories.find(
-      c => c.key === PreferencesCategoriesKeys.ADVERTISING
-    )
-    const essentialInfo = preferencesDialogTemplate?.categories.find(
-      c => c.key === PreferencesCategoriesKeys.ESSENTIAL
-    )
+    const functionalInfo = preferencesDialogTemplate?.categories.find(c => c.key === 'functional')
+    const marketingInfo = preferencesDialogTemplate?.categories.find(c => c.key === 'marketing')
+    const advertisingInfo = preferencesDialogTemplate?.categories.find(c => c.key === 'advertising')
+    const essentialInfo = preferencesDialogTemplate?.categories.find(c => c.key === 'essential')
 
     const buttons = (
       <div>
         <DefaultButton type="button" onClick={onCancel}>
-          {preferencesDialogTemplate?.actionButtons[0]}
+          {actionButtons.cancelValue}
         </DefaultButton>
-        <GreenButton type="submit">{preferencesDialogTemplate?.actionButtons[1]}</GreenButton>
+        <GreenButton type="submit">{actionButtons.saveValue}</GreenButton>
       </div>
     )
 
@@ -146,17 +137,11 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
           <Table>
             <thead>
               <Row>
-                <ColumnHeading scope="col">
-                  {preferencesDialogTemplate?.headings.allowValue}
-                </ColumnHeading>
-                <ColumnHeading scope="col">
-                  {preferencesDialogTemplate?.headings.categoryValue}
-                </ColumnHeading>
-                <ColumnHeading scope="col">
-                  {preferencesDialogTemplate?.headings.purposeValue}
-                </ColumnHeading>
+                <ColumnHeading scope="col">{headings.allowValue}</ColumnHeading>
+                <ColumnHeading scope="col">{headings.categoryValue}</ColumnHeading>
+                <ColumnHeading scope="col">{headings.purposeValue}</ColumnHeading>
                 <ColumnHeading scope="col" className={hideOnMobile}>
-                  {preferencesDialogTemplate?.headings.toolsValue}
+                  {headings.toolsValue}
                 </ColumnHeading>
               </Row>
             </thead>
@@ -176,7 +161,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Allow functional tracking"
                           required
                         />{' '}
-                        {preferencesDialogTemplate?.checkboxes[0]}
+                        {checkboxes.yesValue}
                       </label>
                       <label>
                         <input
@@ -188,7 +173,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Disallow functional tracking"
                           required
                         />{' '}
-                        {preferencesDialogTemplate?.checkboxes[1]}
+                        {checkboxes.noValue}
                       </label>
                     </InputCell>
                     <RowHeading scope="row">{functionalInfo?.name}</RowHeading>
@@ -213,7 +198,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Allow marketing and analytics tracking"
                           required
                         />{' '}
-                        {preferencesDialogTemplate?.checkboxes[0]}
+                        {checkboxes.yesValue}
                       </label>
                       <label>
                         <input
@@ -225,7 +210,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Disallow marketing and analytics tracking"
                           required
                         />{' '}
-                        {preferencesDialogTemplate?.checkboxes[1]}
+                        {checkboxes.noValue}
                       </label>
                     </InputCell>
                     <RowHeading scope="row">{marketingInfo?.name}</RowHeading>
@@ -250,7 +235,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Allow advertising tracking"
                           required
                         />{' '}
-                        {preferencesDialogTemplate?.checkboxes[0]}
+                        {checkboxes.yesValue}
                       </label>
                       <label>
                         <input
@@ -262,7 +247,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                           aria-label="Disallow advertising tracking"
                           required
                         />{' '}
-                        {preferencesDialogTemplate?.checkboxes[1]}
+                        {checkboxes.noValue}
                       </label>
                     </InputCell>
                     <RowHeading scope="row">{advertisingInfo?.name}</RowHeading>
@@ -292,7 +277,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                             aria-label={`Allow "${categoryName}" tracking`}
                             required
                           />{' '}
-                          {preferencesDialogTemplate?.checkboxes[0]}
+                          {checkboxes.yesValue}
                         </label>
                         <label>
                           <input
@@ -304,7 +289,7 @@ export default class PreferenceDialog extends PureComponent<PreferenceDialogProp
                             aria-label={`Disallow "${categoryName}" tracking`}
                             required
                           />{' '}
-                          {preferencesDialogTemplate?.checkboxes[1]}
+                          {checkboxes.noValue}
                         </label>
                       </InputCell>
                       <RowHeading scope="row">{categoryName}</RowHeading>

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,31 +75,28 @@ interface CustomCategory {
   purpose: string
 }
 
-export enum PreferencesCategoriesKeys {
-  FUNCTIONAL = 'functional',
-  MARKETING = 'marketing',
-  ADVERTISING = 'advertising',
-  ESSENTIAL = 'essential'
-}
-
 export interface PreferencesCategories {
-  key: PreferencesCategoriesKeys
+  key: string
   name?: string
   description?: string
   example?: string
 }
 
-interface PreferenceHeadings {
-  allowValue?: string
-  categoryValue?: string
-  purposeValue?: string
-  toolsValue?: string
-}
-
 export interface PreferenceDialogTemplate {
-  headings: PreferenceHeadings
-  checkboxes: string[]
-  actionButtons: string[]
+  headings: {
+    allowValue?: string
+    categoryValue?: string
+    purposeValue?: string
+    toolsValue?: string
+  }
+  checkboxes: {
+    noValue?: string
+    yesValue?: string
+  }
+  actionButtons: {
+    saveValue?: string
+    cancelValue?: string
+  }
   categories: PreferencesCategories[]
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,34 @@ interface CustomCategory {
   purpose: string
 }
 
+export enum PreferencesCategoriesKeys {
+  FUNCTIONAL = 'functional',
+  MARKETING = 'marketing',
+  ADVERTISING = 'advertising',
+  ESSENTIAL = 'essential'
+}
+
+export interface PreferencesCategories {
+  key: PreferencesCategoriesKeys
+  name?: string
+  description?: string
+  example?: string
+}
+
+interface PreferenceHeadings {
+  allowValue?: string
+  categoryValue?: string
+  purposeValue?: string
+  toolsValue?: string
+}
+
+export interface PreferenceDialogTemplate {
+  headings: PreferenceHeadings
+  checkboxes: string[]
+  actionButtons: string[]
+  categories: PreferencesCategories[]
+}
+
 export interface ConsentManagerProps {
   writeKey: string
   otherWriteKeys?: string[]
@@ -100,7 +128,7 @@ export interface ConsentManagerProps {
   customCategories?: CustomCategories
   defaultDestinationBehavior?: DefaultDestinationBehavior
   cdnHost?: string
-  preferencesDialogTemplate?: any
+  preferencesDialogTemplate?: PreferenceDialogTemplate
 }
 
 export interface ActionsBlockProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,7 @@ export interface ConsentManagerProps {
   customCategories?: CustomCategories
   defaultDestinationBehavior?: DefaultDestinationBehavior
   cdnHost?: string
+  preferencesDialogTemplate?: any
 }
 
 export interface ActionsBlockProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,10 @@ export interface PreferenceDialogTemplate {
     saveValue?: string
     cancelValue?: string
   }
+  cancelDialogButtons: {
+    cancelValue?: string
+    backValue?: string
+  }
   categories: PreferencesCategories[]
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,25 +83,25 @@ export interface PreferencesCategories {
 }
 
 export interface PreferenceDialogTemplate {
-  headings: {
+  headings?: {
     allowValue?: string
     categoryValue?: string
     purposeValue?: string
     toolsValue?: string
   }
-  checkboxes: {
+  checkboxes?: {
     noValue?: string
     yesValue?: string
   }
-  actionButtons: {
+  actionButtons?: {
     saveValue?: string
     cancelValue?: string
   }
-  cancelDialogButtons: {
+  cancelDialogButtons?: {
     cancelValue?: string
     backValue?: string
   }
-  categories: PreferencesCategories[]
+  categories?: PreferencesCategories[]
 }
 
 export interface ConsentManagerProps {


### PR DESCRIPTION
This pr introduces a new feature. It allows customizing the texts of the preferences dialog.
It add a property called "preferenceDialogTemplate" where you can pass an object with all the text fields of the dialog you want to customize.

Preference Dialog: 
![image](https://user-images.githubusercontent.com/89416739/135856839-b36411f3-2a2e-4c14-8167-f300a5d6fc55.png)

This pr is related with issue #137 and #33.