### PR TITLE
Update standalone README script version

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ All the options are supported. The callback function also receives these exports
 </script>
 
 <script
-  src="https://unpkg.com/@segment/consent-manager@5.2.0/standalone/consent-manager.js"
+  src="https://unpkg.com/@segment/consent-manager@5.3.0/standalone/consent-manager.js"
   defer
 ></script>
 ```


### PR DESCRIPTION
Hi folks, I spent an hour trying to understand why  `bannerActionsBlock: true` and `bannerHideCloseButton: true` wouldn't work. Turns out the readme standalone version doesn't support those properties and I found that 5.3 is actually the latest published version and works as expected.