### PR TITLE
saveConsent() method fixed

### DIFF
--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -317,7 +317,11 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
       const newDestinations = getNewDestinations(destinations, destinationPreferences)
 
       // If preferences haven't changed, don't reload the page as it's a disruptive experience for end-users
-      if (prevState.havePreferencesChanged || newDestinations.length > 0) {
+      if (
+        prevState.havePreferencesChanged ||
+        newDestinations.length > 0 ||
+        typeof newPreferences === 'boolean'
+      ) {
         savePreferences({
           destinationPreferences,
           customPreferences,


### PR DESCRIPTION
Issue #92 solved. 
Calling saveConsent() with a boolean parameter "true" or "false" did not set the user's preferences or reload the page. 