### PR TITLE
Remove duplicate entries from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,13 +466,6 @@ Options:
 
 The domain the `tracking-preferences` cookie should be scoped to.
 
-##### bannerBackgroundColor
-
-**Type**: `string`
-**Default**: `#1f4160`
-
-The color of the consent banner background.
-
 ##### bannerContent
 
 **Type**: `PropTypes.node`


### PR DESCRIPTION
`bannerBackgroundColor` was included twice, so remove the out-of-place entry.