### PR TITLE
Replace container div with Fragment

### DIFF
--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -204,7 +204,7 @@ const Container: React.FC<ContainerProps> = props => {
   }
 
   return (
-    <div>
+    <>
       {showBanner && props.isConsentRequired && props.newDestinations.length > 0 && (
         <Banner
           innerRef={current => (banner = { current })}
@@ -253,7 +253,7 @@ const Container: React.FC<ContainerProps> = props => {
           preferencesDialogTemplate={props.preferencesDialogTemplate}
         />
       )}
-    </div>
+    </>
   )
 }
 


### PR DESCRIPTION
A small change, but let me explain why we need it.

We have a `div` surrounding our `ConsentManager` component. That `div` applies styles, including a banner:

```tsx
      <div className="border border-red">
        <ConsentManager
          writeKey={writeKey}
```

...which renders to the DOM as:

```html
<div class="border border-mint">
  <div>
    <div class="css-h3yqvb">
      <div class="css-ow1vry">
        <p class="css-1u2wgn3">
          <!-- banner content -->
        </p>
// ...
```

If the user accepts cookies and the banner disappears, then the DOM is now:

```html
<div class="border border-mint">
  <div></div>
</div>
```

i.e. our wrapper `div`, containing an empty `div`. The wrapper div is thus 0px * 0px, but the border is still visible, seen as a 2px square on the page.

This PR removes the empty `div`, replacing it with a `React.Fragment`. If none of the conditions are met in the `container.tsx` render, then only an empty Fragment is returned, which results in nothing being added to the DOM, and we can therefore hide the empty wrapper `div `at our end with some CSS:

```css
div.myClass:empty {
  display: none;
}
```