### PR TITLE
Change enum closeBehavior to type

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Object that opts into users into tracking for the different tracking categories.
 
 ##### closeBehavior
 
-**Type**: `enum|string` or `function`
+**Type**: `string` or `function`
 **Default**: `dismiss`
 
 This option sets the default behavior for the x (close) button on the Consent Manager banner. Available options:

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -10,18 +10,13 @@ import {
   CustomCategories,
   DefaultDestinationBehavior,
   ActionsBlockProps,
-  PreferenceDialogTemplate
+  PreferenceDialogTemplate,
+  CloseBehavior
 } from '../types'
 
 const emitter = new EventEmitter()
 export function openDialog() {
   emitter.emit('openDialog')
-}
-
-export enum CloseBehavior {
-  ACCEPT = 'accept',
-  DENY = 'deny',
-  DISMISS = 'dismiss'
 }
 
 export interface CloseBehaviorFunction {
@@ -108,15 +103,15 @@ const Container: React.FC<ContainerProps> = props => {
   }
 
   const onClose = () => {
-    if (props.closeBehavior === undefined || props.closeBehavior === CloseBehavior.DISMISS) {
+    if (props.closeBehavior === undefined || props.closeBehavior === 'dismiss') {
       return toggleBanner(false)
     }
 
-    if (props.closeBehavior === CloseBehavior.ACCEPT) {
+    if (props.closeBehavior === 'accept') {
       return onAcceptAll()
     }
 
-    if (props.closeBehavior === CloseBehavior.DENY) {
+    if (props.closeBehavior === 'deny') {
       return onDenyAll()
     }
 

--- a/src/standalone.tsx
+++ b/src/standalone.tsx
@@ -4,7 +4,6 @@ import inEU from '@segment/in-eu'
 import inRegions from '@segment/in-regions'
 import { ConsentManager, openConsentManager, doNotTrack } from '.'
 import { ConsentManagerProps, WindowWithConsentManagerConfig, ConsentManagerInput } from './types'
-import { CloseBehavior } from './consent-manager/container'
 import * as preferences from './consent-manager-builder/preferences'
 
 export const version = process.env.VERSION
@@ -55,11 +54,7 @@ if (typeof props.implyConsentOnInteraction === 'string') {
 }
 
 if (props.closeBehavior !== undefined && typeof props.closeBehavior === 'string') {
-  const options = [
-    CloseBehavior.ACCEPT.toString(),
-    CloseBehavior.DENY.toString(),
-    CloseBehavior.DISMISS.toString()
-  ]
+  const options = ['accept', 'deny', 'dismiss']
 
   if (!options.includes(props.closeBehavior)) {
     throw new Error(`ConsentManager: closeBehavior should be one of ${options}`)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { CloseBehavior, CloseBehaviorFunction } from './consent-manager/container'
+import { CloseBehaviorFunction } from './consent-manager/container'
 import { PreferencesManager } from './consent-manager-builder/preferences'
 
 type AJS = SegmentAnalytics.AnalyticsJS & {
@@ -34,6 +34,8 @@ export type ConsentManagerInput = ConsentManagerProps & {
 }
 
 export type DefaultDestinationBehavior = 'enable' | 'disable' | 'imply' | 'ask'
+
+export type CloseBehavior = 'accept' | 'deny' | 'dismiss'
 
 interface StandaloneConsentManagerParams {
   React: unknown

--- a/stories/0-consent-manager.stories.tsx
+++ b/stories/0-consent-manager.stories.tsx
@@ -3,10 +3,10 @@ import cookies from 'js-cookie'
 import { Pane, Heading, Button } from 'evergreen-ui'
 import { ConsentManager, openConsentManager, loadPreferences, onPreferencesSaved } from '../src'
 import { storiesOf } from '@storybook/react'
-import { CloseBehavior, CloseBehaviorFunction } from '../src/consent-manager/container'
+import { CloseBehaviorFunction } from '../src/consent-manager/container'
 import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs'
 import SyntaxHighlighter from 'react-syntax-highlighter'
-import { Preferences } from '../src/types'
+import { CloseBehavior, Preferences } from '../src/types'
 import CookieView from './components/CookieView'
 
 const bannerContent = (
@@ -135,9 +135,9 @@ const ConsentManagerExample = (props: { closeBehavior: CloseBehavior | CloseBeha
 }
 
 storiesOf('React Component / OnClose interactions', module)
-  .add(`Dismiss`, () => <ConsentManagerExample closeBehavior={CloseBehavior.DISMISS} />)
-  .add(`Accept`, () => <ConsentManagerExample closeBehavior={CloseBehavior.ACCEPT} />)
-  .add(`Deny`, () => <ConsentManagerExample closeBehavior={CloseBehavior.DENY} />)
+  .add(`Dismiss`, () => <ConsentManagerExample closeBehavior={'dismiss'} />)
+  .add(`Accept`, () => <ConsentManagerExample closeBehavior={'accept'} />)
+  .add(`Deny`, () => <ConsentManagerExample closeBehavior={'deny'} />)
   .add(`Custom Close Behavior`, () => (
     <ConsentManagerExample
       closeBehavior={categories => ({

--- a/stories/5-custom-categories.stories.tsx
+++ b/stories/5-custom-categories.stories.tsx
@@ -3,10 +3,10 @@ import cookies from 'js-cookie'
 import { Pane, Heading, Button } from 'evergreen-ui'
 import { ConsentManager, openConsentManager, loadPreferences, onPreferencesSaved } from '../src'
 import { storiesOf } from '@storybook/react'
-import { CloseBehavior, CloseBehaviorFunction } from '../src/consent-manager/container'
+import { CloseBehaviorFunction } from '../src/consent-manager/container'
 import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs'
 import SyntaxHighlighter from 'react-syntax-highlighter'
-import { Preferences } from '../src/types'
+import { CloseBehavior, Preferences } from '../src/types'
 import CookieView from './components/CookieView'
 
 const bannerContent = (
@@ -141,9 +141,9 @@ const ConsentManagerExample = (props: { closeBehavior: CloseBehavior | CloseBeha
 }
 
 storiesOf('Custom Categories - Do Not Sell', module)
-  .add(`Dismiss`, () => <ConsentManagerExample closeBehavior={CloseBehavior.DISMISS} />)
-  .add(`Accept`, () => <ConsentManagerExample closeBehavior={CloseBehavior.ACCEPT} />)
-  .add(`Deny`, () => <ConsentManagerExample closeBehavior={CloseBehavior.DENY} />)
+  .add(`Dismiss`, () => <ConsentManagerExample closeBehavior={'dismiss'} />)
+  .add(`Accept`, () => <ConsentManagerExample closeBehavior={'accept'} />)
+  .add(`Deny`, () => <ConsentManagerExample closeBehavior={'deny'} />)
   .add(`Custom Close Behavior`, () => (
     <ConsentManagerExample
       closeBehavior={categories => ({

--- a/stories/6-ccpa-gdpr-example.stories.tsx
+++ b/stories/6-ccpa-gdpr-example.stories.tsx
@@ -8,7 +8,6 @@ import SyntaxHighlighter from 'react-syntax-highlighter'
 import { Preferences } from '../src/types'
 import CookieView from './components/CookieView'
 import inRegions from '@segment/in-regions'
-import { CloseBehavior } from '../src/consent-manager/container'
 
 const bannerContent = (
   <span>
@@ -92,17 +91,13 @@ const ConsentManagerExample = () => {
     functional: false
   }
 
-  const closeBehavior = inCA()
-    ? _categories => caDefaultPreferences
-    : inEU()
-      ? CloseBehavior.DENY
-      : CloseBehavior.ACCEPT
+  const closeBehavior = inCA() ? _categories => caDefaultPreferences : inEU() ? 'deny' : 'accept'
 
   const initialPreferences = inCA()
     ? caDefaultPreferences
     : inEU()
-      ? euDefaultPreferences
-      : undefined
+    ? euDefaultPreferences
+    : undefined
 
   return (
     <Pane>

--- a/stories/7-default-destination-behavior.stories.tsx
+++ b/stories/7-default-destination-behavior.stories.tsx
@@ -6,7 +6,6 @@ import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs'
 import SyntaxHighlighter from 'react-syntax-highlighter'
 import { Preferences, DefaultDestinationBehavior } from '../src/types'
 import CookieView from './components/CookieView'
-import { CloseBehavior } from '../src/consent-manager/container'
 
 const bannerContent = (
   <span>
@@ -89,7 +88,7 @@ const ConsentManagerExample = (props: {
         preferencesDialogContent={preferencesDialogContent}
         cancelDialogTitle={cancelDialogTitle}
         cancelDialogContent={cancelDialogContent}
-        closeBehavior={CloseBehavior.ACCEPT}
+        closeBehavior={'accept'}
         defaultDestinationBehavior={props.defaultDestinationBehavior}
       />
 

--- a/stories/8-consent-manager-actions-block.stories.tsx
+++ b/stories/8-consent-manager-actions-block.stories.tsx
@@ -4,7 +4,6 @@ import { Pane, Heading, Button } from 'evergreen-ui'
 import { ConsentManager, openConsentManager } from '../src'
 import { storiesOf } from '@storybook/react'
 import CookieView from './components/CookieView'
-import { CloseBehavior } from '../src/consent-manager/container'
 
 const bannerContent = (
   <span>
@@ -87,7 +86,7 @@ const ConsentManagerExample = props => {
         preferencesDialogContent={preferencesDialogContent}
         cancelDialogTitle={cancelDialogTitle}
         cancelDialogContent={cancelDialogContent}
-        closeBehavior={CloseBehavior.ACCEPT}
+        closeBehavior={'accept'}
       />
 
       <Pane marginX={100} marginTop={20}>

--- a/stories/9-consent-manager-as-modal.stories.tsx
+++ b/stories/9-consent-manager-as-modal.stories.tsx
@@ -4,7 +4,6 @@ import { Pane, Heading, Button } from 'evergreen-ui'
 import { ConsentManager, openConsentManager } from '../src'
 import { storiesOf } from '@storybook/react'
 import CookieView from './components/CookieView'
-import { CloseBehavior } from '../src/consent-manager/container'
 
 const bannerContent = (
   <span>
@@ -87,7 +86,7 @@ const ConsentManagerExample = props => {
         preferencesDialogContent={preferencesDialogContent}
         cancelDialogTitle={cancelDialogTitle}
         cancelDialogContent={cancelDialogContent}
-        closeBehavior={CloseBehavior.ACCEPT}
+        closeBehavior={'accept'}
         bannerAsModal={props.bannerAsModal}
       />
 


### PR DESCRIPTION
Change the enum to type because  the enum exports has many troubles on the compilation to use the enum on the project importing the enum from the library.

With the _**type**_  exist the security to let only the specific values for closeBehavior.

Fix issue #266 