### PR TITLE
docs: fix link to nextjs example in table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   - [ConsentManager](#consentmanager)
     - [Install](#install)
     - [Example](#example)
-    - [Example in Next.js](#example-in-next.js)
+    - [Example in Next.js](#example-in-nextjs)
     - [ConsentManager Props](#consentmanager-props)
   - [ConsentManagerBuilder](#consentmanagerbuilder)
     - [Install](#install-1)


### PR DESCRIPTION
GitHub filters out dot (.) characters from header ids