### PR TITLE
Fix reload clicking inside banner

### DIFF
--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -314,23 +314,24 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
         newDestinations.length > 0 ||
         typeof newPreferences === 'boolean'
       ) {
-        savePreferences({
-          destinationPreferences,
-          customPreferences,
-          cookieDomain,
-          cookieName,
-          cookieExpires
-        })
-        conditionallyLoadAnalytics({
-          writeKey,
-          destinations,
-          destinationPreferences,
-          isConsentRequired,
-          shouldReload,
-          defaultDestinationBehavior,
-          categoryPreferences: customPreferences
-        })
+        shouldReload = true
       }
+      savePreferences({
+        destinationPreferences,
+        customPreferences,
+        cookieDomain,
+        cookieName,
+        cookieExpires
+      })
+      conditionallyLoadAnalytics({
+        writeKey,
+        destinations,
+        destinationPreferences,
+        isConsentRequired,
+        shouldReload,
+        defaultDestinationBehavior,
+        categoryPreferences: customPreferences
+      })
 
       return {
         ...prevState,

--- a/src/consent-manager-builder/index.tsx
+++ b/src/consent-manager-builder/index.tsx
@@ -334,7 +334,8 @@ export default class ConsentManagerBuilder extends Component<Props, State> {
         customPreferences,
         cookieDomain,
         cookieName,
-        cookieExpires
+        cookieExpires,
+        cookieAttributes
       })
       conditionallyLoadAnalytics({
         writeKey,

--- a/src/consent-manager/banner.tsx
+++ b/src/consent-manager/banner.tsx
@@ -160,7 +160,7 @@ export default class Banner extends PureComponent<BannerProps> {
         <Content asModal={asModal}>
           <P>{content}</P>
           <P>
-            <button type="button" onClick={onChangePreferences}>
+            <button type="button" id="subContentBtn" onClick={onChangePreferences}>
               {subContent}
             </button>
           </P>

--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -143,7 +143,8 @@ const Container: React.FC<ContainerProps> = props => {
     if (
       (banner.current && banner.current.contains(e.target)) ||
       (preferenceDialog.current && preferenceDialog.current.contains(e.target)) ||
-      (cancelDialog.current && cancelDialog.current.contains(e.target))
+      (cancelDialog.current && cancelDialog.current.contains(e.target)) ||
+      'subContentBtn' === e.target.id
     ) {
       return
     }
@@ -180,7 +181,7 @@ const Container: React.FC<ContainerProps> = props => {
 
   const handleSave = () => {
     toggleDialog(false)
-    props.saveConsent()
+    props.saveConsent(undefined, false)
   }
 
   const handleCancel = () => {


### PR DESCRIPTION
Fix #256:

- Add validation to identify when click on SubContent inside Banner
- Change validation on handleSaveConsent to Save Preferences without changes.