### PR TITLE
Fix integrations object key for Amplitude (Actions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
     - [ConsentManagerBuilder Render Props](#consentmanagerbuilder-render-props)
   - [Utility functions](#utility-functions)
   - [Setting Custom Anonymous ID](#setting-custom-anonymous-id)
+  - [Destination Considerations](#destination-considerations)
 - [Development](#development)
 - [Publishing New Version](#publishing-new-version)
 - [License](#license)

--- a/README.md
+++ b/README.md
@@ -919,6 +919,14 @@ _Note: Keep in mind that setting the anonymousId in Analytics.js does not overwr
 
 _There are other ways to override the anonymousID, you can find more information [here][]._
 
+### Destination Considerations
+
+##### Amplitude (Actions)
+
+When an Amplitude (Actions) destination is connected and enabled to your source, Analytics.js will automatically populate a session ID in `integrations.Actions Amplitude.session_id`.
+
+Because the Consent Manager overrides the `session_id` key with a boolean value, `session_id` will have to be directly passed in to event calls by retrieving the value for `analytics_session_id` in localStorage. The value can then be set in an event's `traits` or   `properties` object. 
+
 ## Development
 
 To run our storybook locally, simply do:

--- a/src/consent-manager-builder/fetch-destinations.ts
+++ b/src/consent-manager-builder/fetch-destinations.ts
@@ -21,7 +21,8 @@ async function fetchDestinationForWriteKey(
   // Rename creationName to id to abstract the weird data model
   for (const destination of destinations) {
     // Because of the legacy Fullstory integration the creationName for this integration is the `name`
-    if (destination.name === 'Fullstory (Actions)') {
+    // Adding Amplitude (Actions) here as well to account for session_id
+    if (destination.name === 'Fullstory (Actions)' || destination.name === 'Amplitude (Actions)') {
       destination.id = destination.name
     } else {
       destination.id = destination.creationName


### PR DESCRIPTION
Fix for issue #296 

Currently, when `integrations.All` is `false` and `integrations.Actions Amplitude` is `true`, the latter field will be replaced by the `session_id` that is generated for this destination, resulting in events not reaching Amplitude (Actions).

This can be replicated by enabling an instance of Amplitude (Actions), sending an event with `integrations.Actions Amplitude` set to true, and observing both the outbound request payload and how the event populates in the source's debugger:

Invoking event from source:
![Screen Shot 2023-03-07 at 2 43 38 PM](https://user-images.githubusercontent.com/93934274/223535820-498c0fcf-a5a0-4ad0-aa0d-f5e5cd63bfd2.png)

Outbound request payload:
![Screen Shot 2023-03-07 at 2 43 51 PM](https://user-images.githubusercontent.com/93934274/223535871-c95dadd7-b4fe-48cd-8d3e-5092901445b8.png)

Event populating in Source Debugger:
![Screen Shot 2023-03-07 at 2 44 04 PM](https://user-images.githubusercontent.com/93934274/223535922-b574f64d-a856-41af-bc32-c7734e159d53.png)

This results in the event not sending to Amplitude.

When `integrations.Amplitude (Actions): true` is part of the event invoked from the client, it takes precedence over `integrations.Actions Amplitude.session_id` and the event will deliver to Amplitude as expected, albeit without the session ID:

Invoking event from source:
![Screen Shot 2023-03-07 at 2 44 20 PM](https://user-images.githubusercontent.com/93934274/223536464-1ff5d679-06ee-4471-89be-4579be2d917d.png)

Outbound request payload:
![Screen Shot 2023-03-07 at 2 44 41 PM](https://user-images.githubusercontent.com/93934274/223536593-9b356116-39d0-40cf-8d8c-f1daf840b1d3.png)

Event populating in Source Debugger:
![Screen Shot 2023-03-07 at 2 44 49 PM](https://user-images.githubusercontent.com/93934274/223536625-e6a5cace-5a31-4bef-855f-c343a1263b22.png)

Currently, when `fetchDestinationForWriteKey` is invoked, the destination name for **Amplitude (Actions)** is changed to the creation name **Actions Amplitude**, and the `session_id` will take precedence and override the boolean that is being set in the `integrations` object, as with the first example.

Added an update to `fetchDestinationForWriteKey` so that the destination name is set as `destination.id` if the destination name is "Amplitude (Actions)". With this change, the `integrations` object should now get set to `integrations.Amplitude (Actions)` and deliver events to Amplitude as expected, as with the second example. 

`session_id` can then be passed to an event’s payload by pulling the value from `localStorage.analytics_session_id` and setting it in the `properties` or `traits` object:

Session ID as a property:
![Screen Shot 2023-03-07 at 2 45 19 PM](https://user-images.githubusercontent.com/93934274/223537146-1718f7ba-13ce-4afa-8e74-98f43e45f7ca.png)

Both the event and Session ID get sent to Amplitude:
![Screen Shot 2023-03-07 at 2 45 38 PM](https://user-images.githubusercontent.com/93934274/223537178-1f7c7c0a-0d02-43c8-95ee-e49b5427ab64.png)

Added a section called "Destination Considerations" in the readme that mentions this process.