### PR TITLE
Defer adding the container to the DOM until componentDidMount. Fixes consent form display issues

### DIFF
--- a/src/consent-manager/dialog.tsx
+++ b/src/consent-manager/dialog.tsx
@@ -142,8 +142,6 @@ export default class Dialog extends PureComponent<DialogProps, {}> {
     this.titleId = nanoid()
     this.container = document.createElement('div')
     this.container.setAttribute('data-consent-manager-dialog', '')
-
-    document.body.appendChild(this.container)
   }
 
   render() {
@@ -198,7 +196,7 @@ export default class Dialog extends PureComponent<DialogProps, {}> {
         input.focus()
       }
     }
-
+    document.body.appendChild(this.container)
     document.body.addEventListener('keydown', this.handleEsc, false)
     document.body.style.overflow = 'hidden'
     innerRef(this.container)


### PR DESCRIPTION
In NextJS, if the reactStrictMode is true, appending the container in the constructor does not render the children.

Should fix https://github.com/segmentio/consent-manager/issues/303

I have created a playground to showcase the behavior https://github.com/shofman/nextjs-consent-example. Switching the node_module to point to my branch locally fixs the issue.

When reactStrictMode is true in NextJs, we mount and unmount the component multiple times. The timing of this leaves an empty `<div>` on the page without children. This is what prevents the consent form from appearing in NextJS.

If we defer attaching the container until `componentDidMount`, React cleans up the div properly and ensures that the children are attached properly (displaying the consent dialog).

Disclaimer - I have only tested this in a NextJs context, and not in an ordinary React project. 