### PR TITLE
Avoid hard coding standalone script to version 5.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ All the options are supported. The callback function also receives these exports
 </script>
 
 <script
-  src="https://unpkg.com/@segment/consent-manager@5.3.0/standalone/consent-manager.js"
+  src="https://unpkg.com/@segment/consent-manager@5/standalone/consent-manager.js"
   defer
 ></script>
 ```


### PR DESCRIPTION
The README sets people up with a standalone version that is several minor versions behind, having them run into bugs that have been fixed for years